### PR TITLE
Fix bug with empty input to QuoteBundle query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>com.hedvig.graphql.commons</groupId>
       <artifactId>graphql-commons</artifactId>
-      <version>1.0.6</version>
+      <version>1.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.graphql-java-kickstart</groupId>

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/EmptyBundleQueryException.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/EmptyBundleQueryException.kt
@@ -1,0 +1,10 @@
+package com.hedvig.underwriter.graphql
+
+import com.hedvig.graphql.commons.errors.GraphQlErrorException
+import graphql.ErrorType
+
+class EmptyBundleQueryException : GraphQlErrorException(
+    "You need to supply at least one contractId",
+    ErrorType.ValidationError,
+    mapOf("code" to "InputvalidationError")
+)

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
@@ -31,12 +31,18 @@ class Query @Autowired constructor(
         quoteService.getLatestQuoteForMemberId(env.getToken())?.toResult(env)
             ?: throw IllegalStateException("No quote found for memberId ${env.getToken()}!")
 
-    fun quoteBundle(input: QuoteBundleInputInput, env: DataFetchingEnvironment): QuoteBundle =
-        bundleQuotesService.bundleQuotes(
+    fun quoteBundle(input: QuoteBundleInputInput, env: DataFetchingEnvironment): QuoteBundle {
+
+        if (input.ids.isEmpty()) {
+            throw EmptyBundleQueryException()
+        }
+
+        return bundleQuotesService.bundleQuotes(
             env.getToken(),
             input.ids,
             textKeysLocaleResolver.resolveLocale(env.getAcceptLanguage())
         )
+    }
 
     private fun Quote.toResult(env: DataFetchingEnvironment) = typeMapper.mapToQuoteResult(
         this,

--- a/src/main/kotlin/com/hedvig/underwriter/model/QuoteDao.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/QuoteDao.kt
@@ -94,7 +94,7 @@ interface QuoteDao {
             ORDER BY qr.master_quote_id ASC, qr.id DESC
         """
     )
-    fun find(@BindList("quoteIds") quoteIds: List<UUID>): List<DatabaseQuoteRevision>
+    fun find(@BindList("quoteIds", onEmpty = BindList.EmptyHandling.NULL_STRING) quoteIds: List<UUID>): List<DatabaseQuoteRevision>
 
     @SqlUpdate(
         """

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/BundleQueryIsolationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/BundleQueryIsolationTest.kt
@@ -1,0 +1,62 @@
+package com.hedvig.underwriter.graphql
+
+import com.hedvig.graphql.commons.extensions.getAcceptLanguage
+import com.hedvig.graphql.commons.extensions.getToken
+import com.hedvig.localization.service.LocalizationService
+import com.hedvig.localization.service.TextKeysLocaleResolver
+import com.hedvig.localization.service.TextKeysLocaleResolverImpl
+import com.hedvig.underwriter.graphql.type.QuoteBundleInputInput
+import com.hedvig.underwriter.graphql.type.TypeMapper
+import com.hedvig.underwriter.service.BundleQuotesService
+import com.hedvig.underwriter.service.QuoteService
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class BundleQueryIsolationTest {
+
+    val textKeysLocaleResolver: TextKeysLocaleResolver = TextKeysLocaleResolverImpl()
+
+    @MockK
+    lateinit var quoteService: QuoteService
+
+    @MockK
+    lateinit var bundleQuoteService: BundleQuotesService
+
+    @MockK
+    lateinit var localizationService: LocalizationService
+
+    @MockK
+    lateinit var dataFetchingEnvironment: DataFetchingEnvironment
+
+    @get:Rule
+    val thrown = ExpectedException.none()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `need at least one contractId`() {
+
+        val query = Query(
+            quoteService,
+            bundleQuoteService,
+            textKeysLocaleResolver,
+            TypeMapper(localizationService)
+            )
+
+        every { bundleQuoteService.bundleQuotes(any(), any(), any()) } throws RuntimeException("Should not get here")
+        every { dataFetchingEnvironment.getToken() } returns "1337"
+        every { dataFetchingEnvironment.getAcceptLanguage() } returns "sv-SE"
+
+        thrown.expect(EmptyBundleQueryException::class.java)
+        query.quoteBundle(QuoteBundleInputInput(listOf()), dataFetchingEnvironment)
+    }
+}

--- a/src/test/kotlin/com/hedvig/underwriter/model/QuoteRepositoryImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/model/QuoteRepositoryImplTest.kt
@@ -555,6 +555,15 @@ class QuoteRepositoryImplTest {
     }
 
     @Test
+    fun findQuotesWithEmptyList() {
+        val quoteDao = QuoteRepositoryImpl(jdbiRule.jdbi)
+
+        val result = quoteDao.findQuotes(listOf())
+
+        assert(result.isEmpty())
+    }
+
+    @Test
     fun insertsAndUpdatesBreachedUnderwritingGuidelines() {
         val quoteDao = QuoteRepositoryImpl(jdbiRule.jdbi)
 


### PR DESCRIPTION
Fixes this [bug](https://sentry.io/organizations/hedvig/issues/1646372882/?project=1773000&query=is%3Aunresolved&statsPeriod=14d) which basically happens because we get an empty list to the `quoteBundle` query.
Please look through the solution especially @palmenhq .
