### PR TITLE
Fix/no quote found error

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
@@ -11,9 +11,9 @@ import com.hedvig.underwriter.model.Quote
 import com.hedvig.underwriter.service.BundleQuotesService
 import com.hedvig.underwriter.service.QuoteService
 import graphql.schema.DataFetchingEnvironment
+import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 class Query @Autowired constructor(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
@@ -25,11 +25,11 @@ class Query @Autowired constructor(
 
     fun quote(id: UUID, env: DataFetchingEnvironment) = quoteService.getQuote(id)?.let { quote ->
         quote.toResult(env)
-    } ?: throw IllegalStateException("No quote with id '$id' was found!")
+    } ?: throw QuoteNotFoundQueryException("No quote with id '$id' was found!")
 
     fun lastQuoteOfMember(env: DataFetchingEnvironment) =
         quoteService.getLatestQuoteForMemberId(env.getToken())?.toResult(env)
-            ?: throw QuoteNotFoundQueryException(env.getToken())
+            ?: throw QuoteNotFoundQueryException("No quote found for memberId: ${env.getToken()}")
 
     fun quoteBundle(input: QuoteBundleInputInput, env: DataFetchingEnvironment): QuoteBundle {
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
@@ -11,9 +11,9 @@ import com.hedvig.underwriter.model.Quote
 import com.hedvig.underwriter.service.BundleQuotesService
 import com.hedvig.underwriter.service.QuoteService
 import graphql.schema.DataFetchingEnvironment
-import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 class Query @Autowired constructor(
@@ -29,7 +29,7 @@ class Query @Autowired constructor(
 
     fun lastQuoteOfMember(env: DataFetchingEnvironment) =
         quoteService.getLatestQuoteForMemberId(env.getToken())?.toResult(env)
-            ?: throw IllegalStateException("No quote found for memberId ${env.getToken()}!")
+            ?: throw QuoteNotFoundQueryException(env.getToken())
 
     fun quoteBundle(input: QuoteBundleInputInput, env: DataFetchingEnvironment): QuoteBundle {
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/QuoteNotFoundQueryException.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/QuoteNotFoundQueryException.kt
@@ -3,8 +3,8 @@ package com.hedvig.underwriter.graphql
 import com.hedvig.graphql.commons.errors.GraphQlErrorException
 import graphql.ErrorType
 
-class QuoteNotFoundQueryException(val memberId: String) : GraphQlErrorException(
-    "No quote found for memberId: $memberId",
+class QuoteNotFoundQueryException(message: String) : GraphQlErrorException(
+    message,
     ErrorType.ValidationError,
     mapOf("code" to "InputvalidationError")
 )

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/QuoteNotFoundQueryException.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/QuoteNotFoundQueryException.kt
@@ -1,0 +1,10 @@
+package com.hedvig.underwriter.graphql
+
+import com.hedvig.graphql.commons.errors.GraphQlErrorException
+import graphql.ErrorType
+
+class QuoteNotFoundQueryException(val memberId: String) : GraphQlErrorException(
+    "No quote found for memberId: $memberId",
+    ErrorType.ValidationError,
+    mapOf("code" to "InputvalidationError")
+)

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
@@ -46,6 +46,7 @@ class NoQuoteFoundErrorsTest {
         every { quoteService.getLatestQuoteForMemberId(any()) } returns null
 
         thrown.expect(QuoteNotFoundQueryException::class.java)
+        thrown.expectMessage("No quote found for memberId: 1337")
         query.lastQuoteOfMember(dataFetchingEnvironment)
     }
 }

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
@@ -14,6 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import java.util.UUID
 
 class NoQuoteFoundErrorsTest {
     @MockK
@@ -31,22 +32,35 @@ class NoQuoteFoundErrorsTest {
     @get:Rule
     val thrown = ExpectedException.none()
 
+    lateinit var sut: Query
+
     @Before
     fun setup() {
         MockKAnnotations.init(this)
+        sut =
+            Query(quoteService, bundleQuoteService, TextKeysLocaleResolverImpl(), TypeMapper(localizationService))
     }
 
     @Test
     fun `lastest quote finds no quote`() {
-
-        val query =
-            Query(quoteService, bundleQuoteService, TextKeysLocaleResolverImpl(), TypeMapper(localizationService))
 
         every { dataFetchingEnvironment.getTokenOrNull() } returns "1337"
         every { quoteService.getLatestQuoteForMemberId(any()) } returns null
 
         thrown.expect(QuoteNotFoundQueryException::class.java)
         thrown.expectMessage("No quote found for memberId: 1337")
-        query.lastQuoteOfMember(dataFetchingEnvironment)
+        sut.lastQuoteOfMember(dataFetchingEnvironment)
+    }
+
+    @Test
+    fun `get quote finds no quote`() {
+
+        every { quoteService.getQuote(any()) } returns null
+
+        val quoteId = UUID.fromString("4ad0494c-9906-11ea-a02e-3af9d3902f96")
+
+        thrown.expect(QuoteNotFoundQueryException::class.java)
+        thrown.expectMessage("No quote with id '$quoteId' was found!")
+        sut.quote(quoteId, dataFetchingEnvironment)
     }
 }

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
@@ -1,0 +1,51 @@
+package com.hedvig.underwriter.graphql
+
+import com.hedvig.graphql.commons.extensions.getTokenOrNull
+import com.hedvig.localization.service.LocalizationService
+import com.hedvig.localization.service.TextKeysLocaleResolverImpl
+import com.hedvig.underwriter.graphql.type.TypeMapper
+import com.hedvig.underwriter.service.BundleQuotesService
+import com.hedvig.underwriter.service.QuoteService
+import graphql.schema.DataFetchingEnvironment
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class NoQuoteFoundErrorsTest {
+    @MockK
+    lateinit var quoteService: QuoteService
+
+    @MockK
+    lateinit var bundleQuoteService: BundleQuotesService
+
+    @MockK
+    lateinit var localizationService: LocalizationService
+
+    @MockK
+    lateinit var dataFetchingEnvironment: DataFetchingEnvironment
+
+    @get:Rule
+    val thrown = ExpectedException.none()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `lastest quote finds no quote`() {
+
+        val query =
+            Query(quoteService, bundleQuoteService, TextKeysLocaleResolverImpl(), TypeMapper(localizationService))
+
+        every { dataFetchingEnvironment.getTokenOrNull() } returns "1337"
+        every { quoteService.getLatestQuoteForMemberId(any()) } returns null
+
+        thrown.expect(QuoteNotFoundQueryException::class.java)
+        query.lastQuoteOfMember(dataFetchingEnvironment)
+    }
+}

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/NoQuoteFoundErrorsTest.kt
@@ -10,11 +10,11 @@ import graphql.schema.DataFetchingEnvironment
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import java.util.UUID
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import java.util.UUID
 
 class NoQuoteFoundErrorsTest {
     @MockK


### PR DESCRIPTION
This will not log these exceptions to sentry and instead of this: ```
{
  "errors": [
    {
      "message": "Internal Server Error(s) while executing query"
    }
  ],
  "data": null
}
```
clients will get this:
```
{
  "errors": [
    {
      "message": "Exception while fetching data (/lastQuoteOfMember) : No quote found for memberId: 243250",
      "locations": [
        {
          "line": 7,
          "column": 3
        }
      ],
      "path": [
        "lastQuoteOfMember"
      ],
      "extensions": {
        "code": "InputvalidationError",
        "classification": "DataFetchingException"
      }
    }
  ],
  "data": null
}
```
