### PR TITLE
add missing enum type

### DIFF
--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -231,6 +231,7 @@ enum TypeOfContract {
     NO_HOME_CONTENT_YOUTH_RENT
     NO_TRAVEL
     NO_TRAVEL_YOUTH
+    DK_HOME_CONTENT
 }
 
 type CompleteQuote {


### PR DESCRIPTION
Adding DK_HOME_CONTENT which is missing from the TypeOfContract enum on the graphql schema