### PR TITLE
Fix/finalize onboarding

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/service/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/QuoteServiceImpl.kt
@@ -56,7 +56,8 @@ class QuoteServiceImpl(
                         ErrorCodes.INVALID_STATE,
                         "quote [Id: ${it.id}] must be quoted to update but was really ${it.state} [Quote: $it]"
                     )
-                })
+                }
+            )
             .map { it.clearBreachedUnderwritingGuidelines() }
             .map { it.update(quoteRequest) }
             .flatMap { updatedQuote ->
@@ -120,7 +121,7 @@ class QuoteServiceImpl(
 
         val quote = breachedGuidelinesOrQuote.getQuote()
         if (updateMemberService && quote.memberId != null) {
-            memberService.finalizeOnboarding(quote, quote.email ?: "")
+            memberService.finalizeOnboarding(quote, quote.email!!)
         }
 
         if (quote.memberId != null && quote.email != null) {
@@ -241,11 +242,13 @@ class QuoteServiceImpl(
                 "Underwriting guidelines breached for incomplete quote $quoteId: {}",
                 quote.breachedUnderwritingGuidelines
             )
-            Left(ErrorResponseDto(
-                ErrorCodes.MEMBER_BREACHES_UW_GUIDELINES,
-                "quote cannot be calculated, underwriting guidelines are breached [Quote: $quote",
-                quote.breachedUnderwritingGuidelines.map { BreachedGuideline("Deprecated", it) }
-            ))
+            Left(
+                ErrorResponseDto(
+                    ErrorCodes.MEMBER_BREACHES_UW_GUIDELINES,
+                    "quote cannot be calculated, underwriting guidelines are breached [Quote: $quote",
+                    quote.breachedUnderwritingGuidelines.map { BreachedGuideline("Deprecated", it) }
+                )
+            )
         } else {
             Right(
                 CompleteQuoteResponseDto(

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/StartSignErrors.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/StartSignErrors.kt
@@ -19,6 +19,11 @@ object StartSignErrors {
         "NO_MEMBER_ID_ON_QUOTE"
     )
 
+    val personalInfoNotMatching = StartSignResponse.FailedToStartSign(
+        "quotes must have same firstName, lastName and ss",
+        "PERSONAL_INFO_NOT_MATCHING"
+    )
+
     val targetURLNotProvided =
         StartSignResponse.FailedToStartSign(
             "Bad request: Must provide `successUrl` and `failUrl` when starting norwegian sign",

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/StartSignErrors.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/StartSignErrors.kt
@@ -20,7 +20,7 @@ object StartSignErrors {
     )
 
     val personalInfoNotMatching = StartSignResponse.FailedToStartSign(
-        "quotes must have same firstName, lastName and ss",
+        "quotes must have matching firstName, lastName, ssn, birthDate and email",
         "PERSONAL_INFO_NOT_MATCHING"
     )
 

--- a/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SignStrategyService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SignStrategyService.kt
@@ -76,11 +76,12 @@ class SignStrategyService(
             is SwedishHouseData,
             is SwedishApartmentData -> swedishBankIdSignStrategy
             is NorwegianHomeContentsData,
-            is NorwegianTravelData -> if (env.activeProfiles.contains("staging")) {
-                simpleSignStrategy
-            } else {
-                redirectSignStrategy
-            }
+            is NorwegianTravelData ->
+                if (env.activeProfiles.contains("staging")) {
+                    simpleSignStrategy
+                } else {
+                    redirectSignStrategy
+                }
             is DanishHomeContentsData,
             is DanishAccidentData,
             is DanishTravelData -> redirectSignStrategy
@@ -100,8 +101,10 @@ class SignStrategyService(
 
     private fun List<Quote>.areTwoValidDanishQuotes(): Boolean =
         this.size == 2 &&
-            (this.any { it.data is DanishHomeContentsData } &&
-                (this.any { it.data is DanishAccidentData } || this.any { it.data is DanishTravelData }))
+            (
+                this.any { it.data is DanishHomeContentsData } &&
+                    (this.any { it.data is DanishAccidentData } || this.any { it.data is DanishTravelData })
+                )
 
     private fun List<Quote>.areThreeValidDanishQuotes(): Boolean =
         this.size == 3 &&

--- a/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SwedishBankIdSignStrategy.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SwedishBankIdSignStrategy.kt
@@ -21,7 +21,7 @@ class SwedishBankIdSignStrategy(
 
         val ssn = quotes.safelyGetSsn()
 
-        val isSwitching = quotes[0].currentInsurer != null
+        val isSwitching = quotes.any { quote -> quote.currentInsurer != null}
 
         val signSessionId = signSessionRepository.insert(quoteIds)
 

--- a/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SwedishBankIdSignStrategy.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/quotesSignDataStrategies/SwedishBankIdSignStrategy.kt
@@ -21,7 +21,7 @@ class SwedishBankIdSignStrategy(
 
         val ssn = quotes.safelyGetSsn()
 
-        val isSwitching = quotes.any { quote -> quote.currentInsurer != null}
+        val isSwitching = quotes.any { quote -> quote.currentInsurer != null }
 
         val signSessionId = signSessionRepository.insert(quoteIds)
 

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/FinalizeOnBoardingRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/FinalizeOnBoardingRequest.kt
@@ -7,7 +7,6 @@ import com.hedvig.underwriter.model.firstName
 import com.hedvig.underwriter.model.lastName
 import com.hedvig.underwriter.model.phoneNumber
 import com.hedvig.underwriter.model.ssn
-import com.hedvig.underwriter.service.model.PersonPolicyHolder
 import java.time.LocalDate
 
 class FinalizeOnBoardingRequest(

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/FinalizeOnBoardingRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/FinalizeOnBoardingRequest.kt
@@ -3,7 +3,10 @@ package com.hedvig.underwriter.serviceIntegration.memberService.dtos
 import com.hedvig.underwriter.model.AddressData
 import com.hedvig.underwriter.model.Quote
 import com.hedvig.underwriter.model.birthDate
+import com.hedvig.underwriter.model.firstName
+import com.hedvig.underwriter.model.lastName
 import com.hedvig.underwriter.model.phoneNumber
+import com.hedvig.underwriter.model.ssn
 import com.hedvig.underwriter.service.model.PersonPolicyHolder
 import java.time.LocalDate
 
@@ -34,13 +37,11 @@ class FinalizeOnBoardingRequest(
                 )
             }
 
-            val personPolicyHolder = quote.data as PersonPolicyHolder<*>
-
             return FinalizeOnBoardingRequest(
                 memberId = quote.memberId!!,
-                ssn = personPolicyHolder.ssn,
-                firstName = personPolicyHolder.firstName!!,
-                lastName = personPolicyHolder.lastName!!,
+                ssn = quote.ssn,
+                firstName = quote.firstName,
+                lastName = quote.lastName,
                 email = email,
                 phoneNumber = quote.phoneNumber,
                 address = address,

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
@@ -427,7 +427,7 @@ internal class GraphQlMutationsIntegrationTest {
             id = UUID.fromString("2b9e3b30-5c87-11ea-aa95-fbfb43d88ae6"),
             firstName = "",
             lastName = "",
-            email = null,
+            email = "test@email.com",
             phoneNumber = null,
             currentInsurer = null,
             ssn = "1212121212",

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
@@ -303,7 +303,7 @@ internal class GraphQlMutationsIntegrationTest {
             id = UUID.fromString("2b9e3b30-5c87-11ea-aa95-fbfb43d88ae7"),
             firstName = "",
             lastName = "",
-            email = null,
+            email = "test@email.com",
             phoneNumber = null,
             currentInsurer = null,
             ssn = "21126114165",

--- a/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/graphql/GraphQlMutationsIntegrationTest.kt
@@ -453,7 +453,7 @@ internal class GraphQlMutationsIntegrationTest {
         )
         val createQuote = response.readTree()["data"]["createQuote"]
 
-        verify { memberService.finalizeOnboarding(any(), "") }
+        verify { memberService.finalizeOnboarding(any(), "test@email.com") }
     }
 
     @Test

--- a/src/test/kotlin/com/hedvig/underwriter/service/CompletedSignSessionTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CompletedSignSessionTest.kt
@@ -56,7 +56,6 @@ class CompletedSignSessionTest {
             productPricingService,
             signSessionRepository,
             signStrategyService,
-            mockk(),
             mockk()
         )
     }

--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
@@ -65,7 +65,6 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
             productPricingService,
             mockk(),
             mockk(),
-            mockk(),
             mockk()
         )
 
@@ -99,7 +98,6 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
             quoteRepository,
             memberService,
             productPricingService,
-            mockk(),
             mockk(),
             mockk(),
             mockk()
@@ -141,7 +139,6 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
             quoteRepository,
             memberService,
             productPricingService,
-            mockk(),
             mockk(),
             mockk(),
             mockk()

--- a/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
@@ -4,9 +4,11 @@ import arrow.core.Right
 import com.hedvig.underwriter.model.Name
 import com.hedvig.underwriter.model.Partner
 import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
 import com.hedvig.underwriter.model.QuoteRepository
 import com.hedvig.underwriter.model.QuoteState
 import com.hedvig.underwriter.model.SignSessionRepository
+import com.hedvig.underwriter.model.email
 import com.hedvig.underwriter.model.ssn
 import com.hedvig.underwriter.service.model.StartSignErrors
 import com.hedvig.underwriter.service.model.StartSignResponse
@@ -211,6 +213,10 @@ class SignServiceImplTest {
 
         verify(exactly = 1) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.SwedishBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 
     @Test
@@ -246,6 +252,9 @@ class SignServiceImplTest {
 
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
         assertThat((result as StartSignResponse.FailedToStartSign).errorMessage).isEqualTo("Failed")
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -264,6 +273,9 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -301,6 +313,10 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, null, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.NorwegianBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 
     @Test
@@ -345,6 +361,10 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.NorwegianBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 
     @Test
@@ -371,6 +391,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -391,6 +415,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -411,6 +439,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -436,6 +468,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -477,6 +513,10 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.DanishBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 
     @Test
@@ -523,6 +563,10 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.DanishBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 
     @Test
@@ -554,6 +598,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -568,6 +616,10 @@ class SignServiceImplTest {
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -600,18 +652,21 @@ class SignServiceImplTest {
         cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
     fun failStartSignQuotesWithNoMemberId() {
         val memberId = "1337"
         val quoteIds = listOf(UUID.randomUUID())
-        val quote1 =
-            quote {
-                id = quoteIds[0]
-                data = NorwegianHomeContentDataBuilder()
-                this.memberId = null
-            }
+        val quote1 = quote {
+            id = quoteIds[0]
+            data = NorwegianHomeContentDataBuilder()
+            this.memberId = null
+        }
 
         every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
         every { quoteService.getQuotes(quoteIds) } returns listOf(quote1)
@@ -625,6 +680,10 @@ class SignServiceImplTest {
         assertThat(result.errorCode).isEqualTo(
             StartSignErrors.noMemberIdOnQuote.errorCode
         )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -656,6 +715,150 @@ class SignServiceImplTest {
         assertThat(result.errorCode).isEqualTo(
             StartSignErrors.variousMemberId.errorCode
         )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
+    }
+
+    @Test
+    fun failStartSignQuotesWithDifferentFirstNameFromHedvigToken() {
+        val memberId = "1337"
+        val quoteIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val quote1 =
+            quote {
+                id = quoteIds[0]
+                data = NorwegianHomeContentDataBuilder().copy(firstName = "Tolvan")
+                this.memberId = memberId
+            }
+        val quote2 =
+            quote {
+                id = quoteIds[1]
+                data = NorwegianTravelDataBuilder().copy(firstName = "Tolvansbror")
+                this.memberId = memberId
+            }
+
+        every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
+        every { quoteService.getQuotes(quoteIds) } returns listOf(quote1, quote2)
+
+        val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
+
+        assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+        assertThat((result as StartSignResponse.FailedToStartSign).errorMessage).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorMessage
+        )
+        assertThat(result.errorCode).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorCode
+        )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
+    }
+
+    @Test
+    fun failStartSignQuotesWithDifferentLastNameFromHedvigToken() {
+        val memberId = "1337"
+        val quoteIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val quote1 =
+            quote {
+                id = quoteIds[0]
+                data = NorwegianHomeContentDataBuilder().copy(lastName = "Tolvansson")
+                this.memberId = memberId
+            }
+        val quote2 =
+            quote {
+                id = quoteIds[1]
+                data = NorwegianTravelDataBuilder().copy(lastName = "Tolvansbrorsson")
+                this.memberId = memberId
+            }
+
+        every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
+        every { quoteService.getQuotes(quoteIds) } returns listOf(quote1, quote2)
+
+        val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
+
+        assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+        assertThat((result as StartSignResponse.FailedToStartSign).errorMessage).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorMessage
+        )
+        assertThat(result.errorCode).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorCode
+        )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
+    }
+
+    @Test
+    fun failStartSignQuotesWithDifferentSsnFromHedvigToken() {
+        val memberId = "1337"
+        val quoteIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val quote1 =
+            quote {
+                id = quoteIds[0]
+                data = NorwegianHomeContentDataBuilder().copy(ssn = "123456789")
+                this.memberId = memberId
+            }
+        val quote2 =
+            quote {
+                id = quoteIds[1]
+                data = NorwegianTravelDataBuilder().copy(ssn = "987654321")
+                this.memberId = memberId
+            }
+
+        every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
+        every { quoteService.getQuotes(quoteIds) } returns listOf(quote1, quote2)
+
+        val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
+
+        assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+        assertThat((result as StartSignResponse.FailedToStartSign).errorMessage).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorMessage
+        )
+        assertThat(result.errorCode).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorCode
+        )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
+    }
+
+    @Test
+    fun failStartSignQuotesWithDifferentEmailFromHedvigToken() {
+        val memberId = "1337"
+        val quoteIds = listOf(UUID.randomUUID(), UUID.randomUUID())
+        val quote1 =
+            quote {
+                id = quoteIds[0]
+                data = NorwegianHomeContentDataBuilder().copy(email = "test@hedvig.com")
+                this.memberId = memberId
+            }
+        val quote2 =
+            quote {
+                id = quoteIds[1]
+                data = NorwegianTravelDataBuilder().copy(email = "com@hedvig.test")
+                this.memberId = memberId
+            }
+
+        every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
+        every { quoteService.getQuotes(quoteIds) } returns listOf(quote1, quote2)
+
+        val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
+
+        assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)
+        assertThat((result as StartSignResponse.FailedToStartSign).errorMessage).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorMessage
+        )
+        assertThat(result.errorCode).isEqualTo(
+            StartSignErrors.personalInfoNotMatching.errorCode
+        )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -682,6 +885,10 @@ class SignServiceImplTest {
         assertThat(result.errorCode).isEqualTo(
             StartSignErrors.targetURLNotProvided.errorCode
         )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -700,6 +907,10 @@ class SignServiceImplTest {
         assertThat(result.errorCode).isEqualTo(
             StartSignErrors.memberIsAlreadySigned.errorCode
         )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
     }
 
     @Test
@@ -711,6 +922,7 @@ class SignServiceImplTest {
                 id = quoteId
                 data = NorwegianHomeContentDataBuilder()
                 this.memberId = memberId
+                initiatedFrom = QuoteInitiatedFrom.HOPE
             }
 
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(
@@ -738,6 +950,10 @@ class SignServiceImplTest {
             quoteId,
             SignQuoteFromHopeRequest(activationDate = LocalDate.parse("2020-05-11"), token = null)
         )
+
+        verify(inverse = true) {
+            memberService.finalizeOnboarding(any(), any())
+        }
 
         verify(inverse = true) {
             memberService.signQuote(
@@ -781,5 +997,9 @@ class SignServiceImplTest {
         val result = cut.startSigningQuotes(quoteIds, memberId, null, successUrl, failUrl)
 
         assertThat(result).isInstanceOf(StartSignResponse.DanishBankIdSession::class.java)
+
+        verify {
+            memberService.finalizeOnboarding(quote, quote.email!!)
+        }
     }
 }

--- a/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
@@ -111,8 +111,7 @@ class SignServiceImplTest {
             productPricingService,
             signSessionRepository,
             signStrategyService,
-            customerIO,
-            env
+            customerIO
         )
     }
 
@@ -144,7 +143,6 @@ class SignServiceImplTest {
         every { productPricingService.redeemCampaign(any()) } returns ResponseEntity.ok().build()
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
-        every { env.activeProfiles } returns arrayOf<String>()
 
         cut.signQuote(quoteId, SignQuoteRequest(Name("", ""), LocalDate.now(), "null"))
         verify { customerIO.postSignUpdate(ofType(Quote::class)) }
@@ -174,7 +172,6 @@ class SignServiceImplTest {
         )
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
-        every { env.activeProfiles } returns arrayOf<String>()
 
         cut.signQuote(quoteId, SignQuoteRequest(Name("", ""), LocalDate.now(), "null"))
         verify { customerIO.postSignUpdate(any()) }
@@ -352,10 +349,7 @@ class SignServiceImplTest {
                 failUrl,
                 RedirectCountry.NORWAY
             )
-        } returns UnderwriterStartSignSessionResponse.BankIdRedirect(
-            "redirect url"
-        )
-
+        } returns UnderwriterStartSignSessionResponse.BankIdRedirect("redirect url")
         every { env.activeProfiles } returns arrayOf<String>()
 
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
@@ -385,7 +379,6 @@ class SignServiceImplTest {
 
         every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
         every { quoteService.getQuotes(quoteIds) } returns listOf(quote, quote2)
-        every { env.activeProfiles } returns arrayOf<String>()
 
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
@@ -648,7 +641,6 @@ class SignServiceImplTest {
         every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
         every { quoteService.getQuotes(quoteIds) } returns listOf(quote1, quote2, quote3)
         every { env.activeProfiles } returns arrayOf<String>()
-
         cut.startSigningQuotes(quoteIds, memberId, ipAddress, successUrl, failUrl)
 
         verify(exactly = 0) { signSessionRepository.insert(any()) }
@@ -875,7 +867,6 @@ class SignServiceImplTest {
         every { memberService.isMemberIdAlreadySignedMemberEntity(any()) } returns IsMemberAlreadySignedResponse(false)
         every { quoteService.getQuotes(quoteIds) } returns listOf(quote)
         every { env.activeProfiles } returns arrayOf<String>()
-
         val result = cut.startSigningQuotes(quoteIds, memberId, ipAddress, null, null)
 
         assertThat(result).isInstanceOf(StartSignResponse.FailedToStartSign::class.java)

--- a/src/test/resources/mutations/createApartmentQuote.graphql
+++ b/src/test/resources/mutations/createApartmentQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "191212121212"
+        email: "test@email.com"
         apartment: {
             street: "Kungsgatan 1"
             livingSpace: 30

--- a/src/test/resources/mutations/createDanishHomeContentsQuote.graphql
+++ b/src/test/resources/mutations/createDanishHomeContentsQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         birthDate: "1961-12-21"
+        email: "test@email.com"
         danishHomeContents: {
             street: "Kungsgatan 2"
             livingSpace: 30

--- a/src/test/resources/mutations/createHouseQuote.graphql
+++ b/src/test/resources/mutations/createHouseQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "191212121212"
+        email: "test@email.com"
         house: {
             street: "Kungsgatan 1"
             livingSpace: 30

--- a/src/test/resources/mutations/createNorwegianHomeContentsQuote.graphql
+++ b/src/test/resources/mutations/createNorwegianHomeContentsQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "21126114165"
+        email: "test@email.com"
         norwegianHomeContents: {
             street: "Kungsgatan 2"
             livingSpace: 30

--- a/src/test/resources/mutations/createQuoteWithPhoneNumber.graphql
+++ b/src/test/resources/mutations/createQuoteWithPhoneNumber.graphql
@@ -5,6 +5,7 @@ mutation create {
         lastName: "family"
         ssn: "191212121212"
         phoneNumber: "0812331321"
+        email: "test@email.com"
         house: {
             street: "Kungsgatan 1"
             livingSpace: 30

--- a/src/test/resources/mutations/createSwedishApartmentQuote.graphql
+++ b/src/test/resources/mutations/createSwedishApartmentQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "191212121212"
+        email: "test@email.com"
         swedishApartment: {
             street: "Kungsgatan 1"
             livingSpace: 30

--- a/src/test/resources/mutations/createSwedishHouseQuote.graphql
+++ b/src/test/resources/mutations/createSwedishHouseQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "191212121212"
+        email: "test@email.com"
         swedishHouse: {
             street: "Kungsgatan 1"
             livingSpace: 30

--- a/src/test/resources/mutations/createUnderwritingLimitHitQuote.graphql
+++ b/src/test/resources/mutations/createUnderwritingLimitHitQuote.graphql
@@ -4,6 +4,7 @@ mutation {
         firstName: "first"
         lastName: "family"
         ssn: "191212121212"
+        email: "test@email.com"
         apartment: {
             street: "Kungsgatan 1"
             livingSpace: 999

--- a/src/test/resources/mutations/editQuoteWithPhoneNumber.graphql
+++ b/src/test/resources/mutations/editQuoteWithPhoneNumber.graphql
@@ -5,6 +5,7 @@ mutation create {
         lastName: "family"
         ssn: "191212121212"
         phoneNumber: "0812331321"
+        email: "test@email.com"
         house: {
             street: "Kungsgatan 1"
             livingSpace: 30


### PR DESCRIPTION
# Jira Issue: [HVG-737] 

## What?
- Validate that all quotes have the same personal information when attempting to sign
- Call `finalizeOnboarding` when a sign has started

## Why?
- To ensure the latest member personal information is present on the member at the end of onboarding, currently offer page edits of personal info are not committed to the member in member-service

## Optional checklist
- [x] Boyscouted
- [x] Unit tests written
- [ ] Tested locally



[HVG-737]: https://hedvig.atlassian.net/browse/HVG-737