### PR TITLE
use correct currency in quoteMapper

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
@@ -131,7 +131,7 @@ class QuoteMapper(
             birthDate = quote.birthDate,
             price = MonetaryAmountV2(
                 quote.price!!.toPlainString(),
-                "SEK"
+                quote.currency
             ),
             insuranceCost = insuranceCost,
             details = mapCompleteQuoteResult(


### PR DESCRIPTION
## What?
- while testing rapio we found this :gem: 

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

