### PR TITLE
add a public version of the 'create quote' endpoint, with a slightly tighter API

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
@@ -132,7 +132,16 @@ data class QuoteRequest(
                     quoteRequestDto.danishTravelData != null -> quoteRequestDto.danishTravelData
                     else -> throw IllegalStateException()
                 },
-                productType = null,
+                productType = when {
+                    quoteRequestDto.swedishApartmentData != null -> ProductType.APARTMENT
+                    quoteRequestDto.swedishHouseData != null -> ProductType.HOUSE
+                    quoteRequestDto.norwegianHomeContentsData != null -> ProductType.HOME_CONTENT
+                    quoteRequestDto.norwegianTravelData != null -> ProductType.TRAVEL
+                    quoteRequestDto.danishHomeContentsData != null -> ProductType.HOME_CONTENT
+                    quoteRequestDto.danishAccidentData != null -> ProductType.ACCIDENT
+                    quoteRequestDto.danishTravelData != null -> ProductType.TRAVEL
+                    else -> throw IllegalStateException()
+                },
                 memberId = quoteRequestDto.memberId,
                 originatingProductId = null,
                 startDate = quoteRequestDto.startDate.atStartOfDay().toStockholmInstant(),

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
@@ -16,6 +16,8 @@ import com.hedvig.underwriter.model.lastName
 import com.hedvig.underwriter.model.ssnMaybe
 import com.hedvig.underwriter.serviceIntegration.memberService.dtos.InternalMember
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.extensions.getOldProductType
+import com.hedvig.underwriter.util.toStockholmInstant
+import com.hedvig.underwriter.web.dtos.ExternalQuoteRequestDto
 import com.hedvig.underwriter.web.dtos.QuoteRequestDto
 import java.time.Instant
 import java.time.LocalDate
@@ -95,6 +97,46 @@ data class QuoteRequest(
                 originatingProductId = quoteRequestDto.originatingProductId,
                 startDate = quoteRequestDto.startDate,
                 dataCollectionId = quoteRequestDto.dataCollectionId,
+                phoneNumber = null
+            )
+        }
+
+        fun from(quoteRequestDto: ExternalQuoteRequestDto): QuoteRequest {
+            require(
+                quoteRequestDto.swedishApartmentData != null ||
+                quoteRequestDto.swedishHouseData != null ||
+                quoteRequestDto.norwegianHomeContentsData != null ||
+                quoteRequestDto.norwegianTravelData != null ||
+                quoteRequestDto.danishHomeContentsData != null ||
+                quoteRequestDto.danishAccidentData != null ||
+                quoteRequestDto.danishTravelData != null
+            ) {
+                "Missing minimal quote related data"
+            }
+
+            return QuoteRequest(
+                firstName = quoteRequestDto.firstName,
+                lastName = quoteRequestDto.lastName,
+                email = null,
+                currentInsurer = null,
+                birthDate = quoteRequestDto.birthDate,
+                ssn = quoteRequestDto.ssn,
+                quotingPartner = null,
+                incompleteQuoteData = when {
+                    quoteRequestDto.swedishApartmentData != null -> quoteRequestDto.swedishApartmentData
+                    quoteRequestDto.swedishHouseData != null -> quoteRequestDto.swedishHouseData
+                    quoteRequestDto.norwegianHomeContentsData != null -> quoteRequestDto.norwegianHomeContentsData
+                    quoteRequestDto.norwegianTravelData != null -> quoteRequestDto.norwegianTravelData
+                    quoteRequestDto.danishHomeContentsData != null -> quoteRequestDto.danishHomeContentsData
+                    quoteRequestDto.danishAccidentData != null -> quoteRequestDto.danishAccidentData
+                    quoteRequestDto.danishTravelData != null -> quoteRequestDto.danishTravelData
+                    else -> throw IllegalStateException()
+                },
+                productType = null,
+                memberId = quoteRequestDto.memberId,
+                originatingProductId = null,
+                startDate = quoteRequestDto.startDate.atStartOfDay().toStockholmInstant(),
+                dataCollectionId = null,
                 phoneNumber = null
             )
         }

--- a/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.servlet.http.HttpServletRequest
-import javax.validation.Valid
 
 @RestController
 @RequestMapping("/quotes")
@@ -22,7 +21,7 @@ class ExternalQuoteController(
 ) {
     @PostMapping
     fun createQuote(
-        @Valid @RequestBody body: ExternalQuoteRequestDto,
+        @RequestBody body: ExternalQuoteRequestDto,
         httpServletRequest: HttpServletRequest
     ): ResponseEntity<out Any> {
         val quoteInitiatedFrom = when {

--- a/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
@@ -1,0 +1,44 @@
+package com.hedvig.underwriter.web
+
+import arrow.core.getOrHandle
+import com.hedvig.graphql.commons.extensions.isAndroid
+import com.hedvig.graphql.commons.extensions.isIOS
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
+import com.hedvig.underwriter.service.QuoteService
+import com.hedvig.underwriter.service.model.QuoteRequest
+import com.hedvig.underwriter.web.dtos.ExternalQuoteRequestDto
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import javax.servlet.http.HttpServletRequest
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/quotes")
+class ExternalQuoteController(
+    val quoteService: QuoteService
+) {
+    @PostMapping
+    fun createQuote(
+        @Valid @RequestBody body: ExternalQuoteRequestDto,
+        httpServletRequest: HttpServletRequest
+    ): ResponseEntity<out Any> {
+        val quoteInitiatedFrom = when {
+            httpServletRequest.isAndroid() -> QuoteInitiatedFrom.ANDROID
+            httpServletRequest.isIOS() -> QuoteInitiatedFrom.IOS
+            else -> QuoteInitiatedFrom.APP
+        }
+
+        return quoteService.createQuote(
+            quoteRequest = QuoteRequest.from(body),
+            initiatedFrom = quoteInitiatedFrom,
+            underwritingGuidelinesBypassedBy = null,
+            updateMemberService = false
+        ).bimap(
+            { ResponseEntity.status(422).body(it) },
+            { ResponseEntity.status(200).body(it) }
+        ).getOrHandle { it }
+    }
+}

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/ExternalQuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/ExternalQuoteRequestDto.kt
@@ -1,0 +1,20 @@
+package com.hedvig.underwriter.web.dtos
+
+import com.hedvig.underwriter.service.model.QuoteRequestData
+import java.time.LocalDate
+
+data class ExternalQuoteRequestDto(
+    val memberId: String,
+    val firstName: String,
+    val lastName: String,
+    val birthDate: LocalDate,
+    val ssn: String,
+    val startDate: LocalDate,
+    val swedishHouseData: QuoteRequestData.SwedishHouse?,
+    val swedishApartmentData: QuoteRequestData.SwedishApartment?,
+    val norwegianHomeContentsData: QuoteRequestData.NorwegianHomeContents?,
+    val norwegianTravelData: QuoteRequestData.NorwegianTravel?,
+    val danishHomeContentsData: QuoteRequestData.DanishHomeContents?,
+    val danishAccidentData: QuoteRequestData.DanishAccident?,
+    val danishTravelData: QuoteRequestData.DanishTravel?
+)


### PR DESCRIPTION
# Jira Issue: [HVG-859] 

## What?
Adds a public controller for creating quotes, making it accessible to Giraffe.

## Why?
A specific Giraffe mutation would like to mix-and-match som existing endpoints in services, which is rather difficult (albeit possible) in GraphQL. To make it simpler, we simply expose a public version of the existing "create quote" to be used in the moving flow project.

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally



[HVG-859]: https://hedvig.atlassian.net/browse/HVG-859