### PR TITLE
Fix for always returning currency even if price not sat.

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/QuoteDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/QuoteDto.kt
@@ -55,7 +55,7 @@ data class QuoteDto(
                 id = quote.id,
                 createdAt = quote.createdAt,
                 price = quote.price,
-                currency = quote.currency,
+                currency = quote.currencyWithFallbackOnMarket,
                 productType = quote.productType,
                 state = quote.state,
                 initiatedFrom = quote.initiatedFrom,


### PR DESCRIPTION
# Jira Issue: [] 

## What?
Fix for always returning currency even if price not sat. Enforcing this in earlier commit broke backwards compatibility in `getLatestQuoteFromMemberId` and `getAllQuotesFromMemberId` in quote api.

## Why?
Hope is broken

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

