### PR TITLE
Support for logging request calls in a standardised and nonintrusive way

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Mutation.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Mutation.kt
@@ -23,8 +23,7 @@ import com.hedvig.underwriter.model.QuoteInitiatedFrom
 import com.hedvig.underwriter.service.QuoteService
 import com.hedvig.underwriter.service.SignService
 import com.hedvig.underwriter.service.model.StartSignResponse
-import com.hedvig.underwriter.util.logger
-import com.hedvig.underwriter.util.toMaskedString
+import com.hedvig.underwriter.util.logging.LogCall
 import com.hedvig.underwriter.web.dtos.ErrorCodes
 import com.hedvig.underwriter.web.dtos.ErrorResponseDto
 import graphql.schema.DataFetchingEnvironment
@@ -39,9 +38,8 @@ class Mutation @Autowired constructor(
     private val quoteMapper: QuoteMapper
 ) : GraphQLMutationResolver {
 
+    @LogCall
     fun createQuote(createQuoteInput: CreateQuoteInput, env: DataFetchingEnvironment): CreateQuoteResult {
-
-        logger.info("Create quote: ${createQuoteInput.toMaskedString()}")
 
         val input = when {
             createQuoteInput.apartment != null || createQuoteInput.house != null ||
@@ -85,9 +83,8 @@ class Mutation @Autowired constructor(
         }
     }
 
+    @LogCall
     fun editQuote(input: EditQuoteInput, env: DataFetchingEnvironment): CreateQuoteResult {
-
-        logger.info("Edit quote: ${input.toMaskedString()}")
 
         return responseForEditedQuote(
             quoteService.updateQuote(
@@ -98,9 +95,8 @@ class Mutation @Autowired constructor(
         )
     }
 
+    @LogCall
     fun removeCurrentInsurer(input: RemoveCurrentInsurerInput, env: DataFetchingEnvironment): CreateQuoteResult {
-
-        logger.info("Remove current insurance: ${input.toMaskedString()}")
 
         return responseForEditedQuote(
             quoteService.removeCurrentInsurerFromQuote(input.id),
@@ -108,9 +104,8 @@ class Mutation @Autowired constructor(
         )
     }
 
+    @LogCall
     fun removeStartDate(input: RemoveStartDateInput, env: DataFetchingEnvironment): CreateQuoteResult {
-
-        logger.info("Remove current insurance: ${input.toMaskedString()}")
 
         return responseForEditedQuote(
             quoteService.removeStartDateFromQuote(input.id),
@@ -118,9 +113,8 @@ class Mutation @Autowired constructor(
         )
     }
 
+    @LogCall
     fun signQuotes(input: SignQuotesInput, env: DataFetchingEnvironment): StartSignResponse {
-
-        logger.info("Sign quotes: ${input.toMaskedString()}")
 
         return signService.startSigningQuotes(
             input.quoteIds,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/Query.kt
@@ -13,8 +13,7 @@ import com.hedvig.underwriter.model.Quote
 import com.hedvig.underwriter.service.BundleQuotesService
 import com.hedvig.underwriter.service.QuoteService
 import com.hedvig.underwriter.service.SignService
-import com.hedvig.underwriter.util.logger
-import com.hedvig.underwriter.util.toMaskedString
+import com.hedvig.underwriter.util.logging.LogCall
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -28,26 +27,23 @@ class Query @Autowired constructor(
     private val quoteMapper: QuoteMapper
 ) : GraphQLQueryResolver {
 
+    @LogCall
     fun quote(id: UUID, env: DataFetchingEnvironment): QuoteResult {
-
-        logger.info("Get quote for quoteId=$id")
 
         return quoteService.getQuote(id)?.let { quote ->
             quote.toResult(env)
         } ?: throw QuoteNotFoundQueryException("No quote with id '$id' was found!")
     }
 
+    @LogCall
     fun lastQuoteOfMember(env: DataFetchingEnvironment): QuoteResult {
-
-        logger.info("Get last quote for memberId=${env.getToken()}")
 
         return quoteService.getLatestQuoteForMemberId(env.getToken())?.toResult(env)
             ?: throw QuoteNotFoundQueryException("No quote found for memberId: ${env.getToken()}")
     }
 
+    @LogCall
     fun quoteBundle(input: QuoteBundleInputInput, env: DataFetchingEnvironment): QuoteBundle {
-
-        logger.info("Get quote bundle: memberId=${env.getToken()}, request: ${input.toMaskedString()}")
 
         if (input.ids.isEmpty()) {
             throw EmptyBundleQueryException()
@@ -69,10 +65,8 @@ class Query @Autowired constructor(
         )
     }
 
+    @LogCall
     fun signMethodForQuotes(input: List<UUID>): SignMethod {
-
-        logger.info("Get sign method for quotes: quoteIds=$input")
-
         return signService.getSignMethodFromQuotes(input).toGraphQL()
     }
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/BundledQuote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/BundledQuote.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.graphql.commons.type.MonetaryAmountV2
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishAccidentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishAccidentInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 class CreateDanishAccidentInput(
     @Masked val street: String,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishHomeContentsInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishHomeContentsInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.model.DanishHomeContentsType as InternalDanishHomeContentsType
 
 data class CreateDanishHomeContentsInput(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishTravelInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateDanishTravelInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 class CreateDanishTravelInput(
     @Masked val street: String,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateNorwegianHomeContentsInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateNorwegianHomeContentsInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.model.NorwegianHomeContentsType as InternalNorwegianHomeContentsType
 
 data class CreateNorwegianHomeContentsInput(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateQuoteInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateQuoteInput.kt
@@ -8,7 +8,7 @@ import com.hedvig.underwriter.model.ProductType
 import com.hedvig.underwriter.model.birthDateFromNorwegianSsn
 import com.hedvig.underwriter.model.birthDateFromSwedishSsn
 import com.hedvig.underwriter.service.model.QuoteRequest
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.util.toStockholmInstant
 import java.time.LocalDate
 import java.util.UUID

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateSwedishApartmentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateSwedishApartmentInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class CreateSwedishApartmentInput(
     @Masked val street: String,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateSwedishHouseInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/CreateSwedishHouseInput.kt
@@ -2,7 +2,7 @@ package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.extensions.toExtraBuilding
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class CreateSwedishHouseInput(
     @Masked val street: String,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishAccidentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishAccidentInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class EditDanishAccidentInput(
     @Masked val street: String?,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishHomeContentsInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishHomeContentsInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.model.DanishHomeContentsType as InternalDanishHomeContentsType
 
 data class EditDanishHomeContentsInput(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishTravelInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditDanishTravelInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class EditDanishTravelInput(
     @Masked val street: String?,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditNorwegianHomeContentsInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditNorwegianHomeContentsInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.model.NorwegianHomeContentsType as InternalNorwegianHomeContentsType
 
 data class EditNorwegianHomeContentsInput(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditQuoteInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditQuoteInput.kt
@@ -8,7 +8,7 @@ import com.hedvig.underwriter.model.birthDateFromDanishSsn
 import com.hedvig.underwriter.model.birthDateFromNorwegianSsn
 import com.hedvig.underwriter.model.birthDateFromSwedishSsn
 import com.hedvig.underwriter.service.model.QuoteRequest
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.util.toStockholmInstant
 import java.time.LocalDate
 import java.util.UUID

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditSwedishApartmentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditSwedishApartmentInput.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class EditSwedishApartmentInput(
     @Masked val street: String?,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditSwedishHouseInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/EditSwedishHouseInput.kt
@@ -2,7 +2,7 @@ package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.underwriter.extensions.toExtraBuilding
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class EditSwedishHouseInput(
     @Masked val street: String?,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/IncompleteQuoteDetails.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/IncompleteQuoteDetails.kt
@@ -1,6 +1,6 @@
 package com.hedvig.underwriter.graphql.type
 
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 sealed class IncompleteQuoteDetails {
     data class IncompleteApartmentQuoteDetails(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteDetails.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteDetails.kt
@@ -1,6 +1,6 @@
 package com.hedvig.underwriter.graphql.type
 
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 sealed class QuoteDetails {
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteResult.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteResult.kt
@@ -2,7 +2,7 @@ package com.hedvig.underwriter.graphql.type
 
 import com.hedvig.graphql.commons.type.MonetaryAmountV2
 import com.hedvig.underwriter.graphql.type.depricated.CompleteQuoteDetails
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CompleteQuoteDetails.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CompleteQuoteDetails.kt
@@ -2,7 +2,7 @@ package com.hedvig.underwriter.graphql.type.depricated
 
 import com.hedvig.underwriter.graphql.type.ApartmentType
 import com.hedvig.underwriter.graphql.type.ExtraBuilding
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 @Deprecated("Use QuoteDetails")
 sealed class CompleteQuoteDetails {

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CreateApartmentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CreateApartmentInput.kt
@@ -2,10 +2,11 @@ package com.hedvig.underwriter.graphql.type.depricated
 
 import com.hedvig.underwriter.graphql.type.ApartmentType
 import com.hedvig.underwriter.service.model.QuoteRequestData
+import com.hedvig.underwriter.util.logging.Masked
 
 @Deprecated("Use CreateSwedishApartmentInput")
 data class CreateApartmentInput(
-    val street: String,
+    @Masked val street: String,
     val zipCode: String,
     val householdSize: Int,
     val livingSpace: Int,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CreateHouseInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/CreateHouseInput.kt
@@ -3,10 +3,11 @@ package com.hedvig.underwriter.graphql.type.depricated
 import com.hedvig.underwriter.extensions.toExtraBuilding
 import com.hedvig.underwriter.graphql.type.ExtraBuildingInput
 import com.hedvig.underwriter.service.model.QuoteRequestData
+import com.hedvig.underwriter.util.logging.Masked
 
 @Deprecated("Use CreateSwedishHouseInput")
 data class CreateHouseInput(
-    val street: String,
+    @Masked val street: String,
     val zipCode: String,
     val householdSize: Int,
     val livingSpace: Int,

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/EditApartmentInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/EditApartmentInput.kt
@@ -2,7 +2,7 @@ package com.hedvig.underwriter.graphql.type.depricated
 
 import com.hedvig.underwriter.graphql.type.ApartmentType
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 @Deprecated("Use EditSwedishApartmentInput")
 data class EditApartmentInput(

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/EditHouseInput.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/depricated/EditHouseInput.kt
@@ -3,7 +3,7 @@ package com.hedvig.underwriter.graphql.type.depricated
 import com.hedvig.underwriter.extensions.toExtraBuilding
 import com.hedvig.underwriter.graphql.type.ExtraBuildingInput
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 @Deprecated("Use EditSwedishHouseInput")
 data class EditHouseInput(

--- a/src/main/kotlin/com/hedvig/underwriter/model/Name.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Name.kt
@@ -1,6 +1,8 @@
 package com.hedvig.underwriter.model
 
+import com.hedvig.underwriter.util.logging.Masked
+
 data class Name(
-    val firstName: String,
-    val lastName: String
+    @Masked val firstName: String,
+    @Masked val lastName: String
 )

--- a/src/main/kotlin/com/hedvig/underwriter/model/QuoteData.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/QuoteData.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.hedvig.underwriter.service.model.PersonPolicyHolder
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import org.jdbi.v3.json.Json
 import java.time.LocalDate
 import java.util.UUID

--- a/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
@@ -32,7 +32,7 @@ import com.hedvig.underwriter.serviceIntegration.memberService.dtos.UpdateSsnReq
 import com.hedvig.underwriter.serviceIntegration.productPricing.ProductPricingService
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.RedeemCampaignDto
 import com.hedvig.underwriter.util.logger
-import com.hedvig.underwriter.util.toMaskedString
+import com.hedvig.underwriter.util.logging.toMaskedString
 import com.hedvig.underwriter.web.dtos.ErrorCodes
 import com.hedvig.underwriter.web.dtos.ErrorResponseDto
 import com.hedvig.underwriter.web.dtos.SignQuoteFromHopeRequest

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequest.kt
@@ -16,6 +16,7 @@ import com.hedvig.underwriter.model.lastName
 import com.hedvig.underwriter.model.ssnMaybe
 import com.hedvig.underwriter.serviceIntegration.memberService.dtos.InternalMember
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.extensions.getOldProductType
+import com.hedvig.underwriter.util.logging.Masked
 import com.hedvig.underwriter.util.toStockholmInstant
 import com.hedvig.underwriter.web.dtos.ExternalQuoteRequestDto
 import com.hedvig.underwriter.web.dtos.QuoteRequestDto
@@ -25,13 +26,13 @@ import java.time.ZoneId
 import java.util.UUID
 
 data class QuoteRequest(
-    val firstName: String?,
-    val lastName: String?,
+    @Masked val firstName: String?,
+    @Masked val lastName: String?,
     val email: String?,
-    val phoneNumber: String?,
+    @Masked val phoneNumber: String?,
     val currentInsurer: String?,
     val birthDate: LocalDate?,
-    val ssn: String?,
+    @Masked val ssn: String?,
     val quotingPartner: Partner?,
     val productType: ProductType? = null,
     @field:JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequestData.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequestData.kt
@@ -14,7 +14,7 @@ import com.hedvig.underwriter.model.QuoteData
 import com.hedvig.underwriter.model.SwedishApartmentData
 import com.hedvig.underwriter.model.SwedishHouseData
 import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.ExtraBuildingRequestDto
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.util.UUID
 
 sealed class QuoteRequestData {

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteSchema.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteSchema.kt
@@ -9,6 +9,7 @@ import com.hedvig.underwriter.model.ApartmentProductSubType
 import com.hedvig.underwriter.model.DanishHomeContentsType
 import com.hedvig.underwriter.model.ExtraBuildingType
 import com.hedvig.underwriter.model.NorwegianHomeContentsType
+import com.hedvig.underwriter.util.logging.Masked
 
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "id")
@@ -26,7 +27,7 @@ sealed class QuoteSchema {
         @JsonSchema(title = "Line Of Business", required = true)
         val lineOfBusiness: ApartmentProductSubType,
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 5, maxLength = 5)
         val zipCode: String,
         @JsonSchema(title = "City", required = false)
@@ -39,7 +40,7 @@ sealed class QuoteSchema {
 
     data class SwedishHouse(
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 5, maxLength = 5)
         val zipCode: String,
         @JsonSchema(title = "City", required = false)
@@ -75,7 +76,7 @@ sealed class QuoteSchema {
         @JsonSchema(title = "Line Of Business", required = true)
         val lineOfBusiness: NorwegianHomeContentsType,
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 4, maxLength = 4)
         val zipCode: String,
         @JsonSchema(title = "City", required = false)
@@ -103,7 +104,7 @@ sealed class QuoteSchema {
         @JsonSchema(title = "Line Of Business", required = true)
         val lineOfBusiness: DanishHomeContentsType,
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 4, maxLength = 4)
         val zipCode: String,
         @JsonSchema(title = "Living Space", required = true, min = 0.0)
@@ -118,7 +119,7 @@ sealed class QuoteSchema {
 
     data class DanishAccident(
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 4, maxLength = 4)
         val zipCode: String,
         @JsonSchema(title = "Number Co-Insured", required = true, min = 0.0)
@@ -131,7 +132,7 @@ sealed class QuoteSchema {
 
     data class DanishTravel(
         @JsonSchema(title = "Street", required = true)
-        val street: String,
+        @Masked val street: String,
         @JsonSchema(title = "Zip Code", required = true, minLength = 4, maxLength = 4)
         val zipCode: String,
         @JsonSchema(title = "Number Co-Insured", required = true, min = 0.0)

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/Address.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/Address.kt
@@ -1,7 +1,9 @@
 package com.hedvig.underwriter.serviceIntegration.memberService.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
+
 class Address(
-    val street: String,
+    @Masked val street: String,
     val city: String,
     val zipCode: String,
     val apartmentNo: String,

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/AddressMemberService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/AddressMemberService.kt
@@ -1,7 +1,9 @@
 package com.hedvig.underwriter.serviceIntegration.memberService.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
+
 data class AddressMemberService(
-    var street: String? = null,
+    @Masked var street: String? = null,
     var city: String? = null,
     var zipCode: String? = null,
     var apartmentNo: String? = null,

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/InternalMember.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/InternalMember.kt
@@ -1,5 +1,6 @@
 package com.hedvig.underwriter.serviceIntegration.memberService.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.Instant
 import java.time.LocalDate
 
@@ -11,18 +12,18 @@ enum class Gender {
 data class InternalMember(
     val memberId: Long,
     val status: String?,
-    val ssn: String,
+    @Masked val ssn: String,
     val gender: Gender?,
-    val firstName: String,
-    val lastName: String,
-    val street: String?,
+    @Masked val firstName: String,
+    @Masked val lastName: String,
+    @Masked val street: String?,
     val floor: Int?,
     val apartment: String?,
     val city: String?,
     val zipCode: String?,
     val country: String?,
-    val email: String?,
-    val phoneNumber: String?,
+    @Masked val email: String?,
+    @Masked val phoneNumber: String?,
     val birthDate: LocalDate,
     val signedOn: Instant?,
     val createdOn: Instant?,

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/UpdateContactInformationRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/memberService/dtos/UpdateContactInformationRequest.kt
@@ -1,12 +1,14 @@
 package com.hedvig.underwriter.serviceIntegration.memberService.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
+
 data class UpdateContactInformationRequest(
     var memberId: String,
-    val firstName: String,
-    val lastName: String,
-    val email: String,
-    val phoneNumber: String,
+    @Masked val firstName: String,
+    @Masked val lastName: String,
+    @Masked val email: String,
+    @Masked val phoneNumber: String,
     val addressMemberService: AddressMemberService,
-    val ssn: String
+    @Masked val ssn: String
 
 )

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/notificationService/dtos/QuoteCreatedEvent.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/notificationService/dtos/QuoteCreatedEvent.kt
@@ -1,17 +1,18 @@
 package com.hedvig.underwriter.serviceIntegration.notificationService.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
 import java.math.BigDecimal
 import java.util.UUID
 
 data class QuoteCreatedEvent(
     val memberId: String,
     val quoteId: UUID,
-    val firstName: String,
-    val lastName: String,
-    val street: String?,
+    @Masked val firstName: String,
+    @Masked val lastName: String,
+    @Masked val street: String?,
     val postalCode: String?,
-    val email: String,
-    val ssn: String?,
+    @Masked val email: String,
+    @Masked val ssn: String?,
     val initiatedFrom: String,
     val attributedTo: String,
     val productType: String,

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/Address.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/Address.kt
@@ -1,9 +1,10 @@
 package com.hedvig.underwriter.serviceIntegration.productPricing.dtos
 
+import com.hedvig.underwriter.util.logging.Masked
 import com.neovisionaries.i18n.CountryCode
 
 data class Address(
-    val street: String,
+    @Masked val street: String,
     val coLine: String? = null,
     val postalCode: String,
     val city: String? = null,

--- a/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCall.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCall.kt
@@ -1,0 +1,5 @@
+package com.hedvig.underwriter.util.logging
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LogCall()

--- a/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCallAspect.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCallAspect.kt
@@ -1,0 +1,33 @@
+package com.hedvig.underwriter.util.logging
+
+import com.hedvig.underwriter.util.logger
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class LogCallAspect {
+
+    @Suppress("TooGenericExceptionCaught")
+    @Around("@annotation(com.hedvig.underwriter.util.logging.LogCall)")
+    fun logExecutionTime(joinPoint: ProceedingJoinPoint): Any {
+        val start = System.currentTimeMillis()
+        val signature = joinPoint.signature.toShortString()
+        val result = try {
+            logger.info("Calling $signature, parameters: [${getParams(joinPoint.args)}]")
+            joinPoint.proceed()
+        } catch (throwable: Throwable) {
+            logger.error("Exception during executing $signature,", throwable)
+            throw throwable
+        }
+        val duration = System.currentTimeMillis() - start
+        logger.info("Finished executing: $signature, returned: '$result', duration: $duration ms")
+        return result
+    }
+
+    private fun getParams(args: Array<Any>) =
+        args.map { it.toMaskedString() }
+            .joinToString(", ")
+}

--- a/src/main/kotlin/com/hedvig/underwriter/util/logging/Masked.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/util/logging/Masked.kt
@@ -1,4 +1,4 @@
-package com.hedvig.underwriter.util
+package com.hedvig.underwriter.util.logging
 
 import java.lang.reflect.Modifier
 import java.util.LinkedList
@@ -37,10 +37,11 @@ private fun reflectionToString(obj: Any): String {
 
             prop.isAccessible = true
 
+            val value = prop.get(obj)
             val masked = prop.getAnnotation(Masked::class.java)
-            val value = if (masked != null) "***" else prop.get(obj)?.toMaskedString()
+            val maskedString = if (masked != null && value != null) "***" else value?.toMaskedString()
 
-            s += "${prop.name}=" + value
+            s += "${prop.name}=" + maskedString
         }
         clazz = clazz.superclass
     }

--- a/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/ExternalQuoteController.kt
@@ -6,6 +6,7 @@ import com.hedvig.graphql.commons.extensions.isIOS
 import com.hedvig.underwriter.model.QuoteInitiatedFrom
 import com.hedvig.underwriter.service.QuoteService
 import com.hedvig.underwriter.service.model.QuoteRequest
+import com.hedvig.underwriter.util.logging.LogCall
 import com.hedvig.underwriter.web.dtos.ExternalQuoteRequestDto
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,6 +21,7 @@ class ExternalQuoteController(
     val quoteService: QuoteService
 ) {
     @PostMapping
+    @LogCall
     fun createQuote(
         @RequestBody body: ExternalQuoteRequestDto,
         httpServletRequest: HttpServletRequest

--- a/src/main/kotlin/com/hedvig/underwriter/web/QuoteSchemaController.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/QuoteSchemaController.kt
@@ -7,6 +7,7 @@ import com.hedvig.underwriter.service.QuoteSchemaService
 import com.hedvig.underwriter.service.QuoteService
 import com.hedvig.underwriter.service.model.QuoteRequest
 import com.hedvig.underwriter.service.model.QuoteSchema
+import com.hedvig.underwriter.util.logging.LogCall
 import com.hedvig.underwriter.web.dtos.ErrorCodes
 import com.hedvig.underwriter.web.dtos.ErrorResponseDto
 import org.springframework.http.ResponseEntity
@@ -26,6 +27,7 @@ class QuoteSchemaController(
     val quoteService: QuoteService
 ) {
     @GetMapping("{quoteId}")
+    @LogCall
     fun getSchemaByQuoteId(@PathVariable quoteId: UUID): Any {
         return quoteSchemaService.getSchemaByQuoteId(quoteId) ?: return ResponseEntity.status(404).body(
             ErrorResponseDto(
@@ -36,6 +38,7 @@ class QuoteSchemaController(
     }
 
     @GetMapping("{quoteId}/data")
+    @LogCall
     fun getSchemaDataByQuoteId(@PathVariable quoteId: UUID): Any {
         return quoteSchemaService.getSchemaDataByQuoteId(quoteId) ?: return ResponseEntity.status(404).body(
             ErrorResponseDto(
@@ -46,11 +49,13 @@ class QuoteSchemaController(
     }
 
     @GetMapping("contract/{contractType}")
+    @LogCall
     fun getSchemaByContractType(@PathVariable contractType: ContractType): JsonNode {
         return quoteSchemaService.getSchemaByContractType(contractType)
     }
 
     @PostMapping("{quoteId}/update")
+    @LogCall
     fun updateQuoteBySchemaData(
         @PathVariable quoteId: UUID,
         @RequestBody body: QuoteSchema,
@@ -74,6 +79,7 @@ class QuoteSchemaController(
     }
 
     @PostMapping("/{memberId}/create")
+    @LogCall
     fun createQuoteForMemberBySchemaData(
         @PathVariable memberId: String,
         @RequestBody body: QuoteSchema,

--- a/src/main/kotlin/com/hedvig/underwriter/web/SignSessionController.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/SignSessionController.kt
@@ -2,6 +2,7 @@ package com.hedvig.underwriter.web
 
 import com.hedvig.underwriter.service.SignService
 import com.hedvig.underwriter.service.model.CompleteSignSessionData
+import com.hedvig.underwriter.util.logging.LogCall
 import com.hedvig.underwriter.web.dtos.SignRequest
 import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,6 +21,7 @@ class SignSessionController @Autowired constructor(
 ) {
 
     @PostMapping("/swedishBankid/{sessionId}/completed")
+    @LogCall
     fun swedishQuoteWasSigned(
         @PathVariable sessionId: UUID,
         @RequestBody requestBody: SignRequest
@@ -34,6 +36,7 @@ class SignSessionController @Autowired constructor(
     }
 
     @PostMapping("/{sessionId}/completed")
+    @LogCall
     fun signSessionComplete(
         @PathVariable sessionId: UUID
     ) {

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/ExternalQuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/ExternalQuoteRequestDto.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.web.dtos
 
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.LocalDate
 
 data class ExternalQuoteRequestDto(

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/QuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/QuoteRequestDto.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.hedvig.underwriter.model.Partner
 import com.hedvig.underwriter.model.ProductType
 import com.hedvig.underwriter.service.model.QuoteRequestData
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
@@ -1,7 +1,7 @@
 package com.hedvig.underwriter.web.dtos
 
 import com.hedvig.underwriter.model.Name
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 import java.time.LocalDate
 
 data class SignQuoteRequestDto(

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
@@ -1,6 +1,7 @@
 package com.hedvig.underwriter.web.dtos
 
 import com.hedvig.underwriter.model.Name
+import com.hedvig.underwriter.util.logging.Masked
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
@@ -8,9 +9,9 @@ import java.util.UUID
 data class SignQuotesRequestDto(
     val quoteIds: List<UUID>,
     val name: Name?,
-    val ssn: String?,
+    @Masked val ssn: String?,
     val startDate: LocalDate?,
-    val email: String,
+    @Masked val email: String,
     val price: BigDecimal? = null, // Used for bundle verification
     val currency: String? = null
 ) {

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/UnderwriterQuoteSignRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/UnderwriterQuoteSignRequest.kt
@@ -1,6 +1,6 @@
 package com.hedvig.underwriter.web.dtos
 
-import com.hedvig.underwriter.util.Masked
+import com.hedvig.underwriter.util.logging.Masked
 
 data class UnderwriterQuoteSignRequest(
     @Masked val ssn: String

--- a/src/test/kotlin/com/hedvig/underwriter/util/logging/MaskedTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/util/logging/MaskedTest.kt
@@ -1,4 +1,4 @@
-package com.hedvig.underwriter.util
+package com.hedvig.underwriter.util.logging
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
@@ -141,7 +141,7 @@ class MaskedTest {
 
         val o = Data("sdf", 123, true, 12.345, null, NestedData("asdds", 134, false, 34.121, "asda"))
 
-        assertThat(o.toMaskedString()).isEqualTo("Data(a=sdf, b=123, c=***, d=***, e=***, f=NestedData(a=***, b=***, c=false, d=34.121, e=asda))")
+        assertThat(o.toMaskedString()).isEqualTo("Data(a=sdf, b=123, c=***, d=***, e=null, f=NestedData(a=***, b=***, c=false, d=34.121, e=asda))")
     }
 
     @Test
@@ -165,7 +165,7 @@ class MaskedTest {
 
         val o = mapOf(1 to Data("sdf", 123, true, 12.345, null, NestedData("asdds", 134, false, 34.121, "asda")), 2 to null)
 
-        assertThat(o.toMaskedString()).isEqualTo("{1=Data(a=sdf, b=123, c=***, d=***, e=***, f=NestedData(a=***, b=***, c=false, d=34.121, e=asda)), 2=null}")
+        assertThat(o.toMaskedString()).isEqualTo("{1=Data(a=sdf, b=123, c=***, d=***, e=null, f=NestedData(a=***, b=***, c=false, d=34.121, e=asda)), 2=null}")
     }
 
     @Test


### PR DESCRIPTION
## What?
Added support for logging request calls in a simple, standardised, nonintrusive and gdpr safe way using spring-aop.

By annotating a method with `@LogCall` will result in calls to it to be logged out with input parameters as well as returned value. Logged objects data will be masked out for fields marked with the `@Masked` annotation.

E.g. a call to this:
```
    @PostMapping
    @LogCall
    fun createQuote(
        @Valid @RequestBody requestDto: QuoteRequestDto,
        httpServletRequest: HttpServletRequest
    ): ResponseEntity<out Any>
```
...will result in following logs:
```
Calling QuoteController.createQuote(..), parameters: [QuoteRequestDto(firstName=null, lastName=null, email=null, currentInsurer=null, birthDate=1988-01-01, ssn=null, quotingPartner=HEDVIG, productType=HOME_CONTENT, incompleteQuoteData=NorwegianHomeContents(street=***, zipCode=1234, city=ApCity, coInsured=1, livingSpace=122, isYouth=false, subType=OWN)), ch.qos.logback.access.servlet.TeeHttpServletRequest@34892a6b]
...

Finished executing: QuoteController.createQuote(..), returned: '<200,CompleteQuoteResponseDto(id=a273062c-0465-47bf-9aac-2108324582ae, price=200, currency=NOK, validTo=2021-04-11T07:19:15.122856Z),[]>', duration: 40 ms
```

All the magic is done in the new small `LogCallAspect` class. The rest of the changes in this PR is just to incorporate the `@LogCall` and `@Masked` annotation into underwriter service.

There is room for improvements, e.g. I could not manage to make `@LogCall` work on class level which would be very convenient. This due to some strange aop error complaining at a LiquidBaseConfig thingy.

After battle testing this in the underwriter service and get it right I think this logic should be extracted into a sharable lib for other services to start using.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

