### PR TITLE
Masking the method result logged in `LogAspect`.

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCallAspect.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/util/logging/LogCallAspect.kt
@@ -23,7 +23,7 @@ class LogCallAspect {
             throw throwable
         }
         val duration = System.currentTimeMillis() - start
-        logger.info("Finished executing: $signature, returned: '$result', duration: $duration ms")
+        logger.info("Finished executing: $signature, returned: '${result.toMaskedString()}', duration: $duration ms")
         return result
     }
 


### PR DESCRIPTION
## What?
The method results are now logged with pin masking which was forgotten.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

