### PR TITLE
Block re-quoting

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -36,9 +36,12 @@ val Quote.ssnMaybe
     get() = (data as? PersonPolicyHolder<*>)?.ssn
 
 val Quote.birthDate
+    get() = birthDateMaybe
+        ?: throw RuntimeException("No birthDate on Quote! $this")
+
+val Quote.birthDateMaybe
     get() = (data as? PersonPolicyHolder<*>)?.birthDate
         ?: recoverBirthDateFromSSN()
-        ?: throw RuntimeException("No birthDate on Quote! $this")
 
 val Quote.email
     get() = (data as? PersonPolicyHolder<*>)?.email

--- a/src/main/kotlin/com/hedvig/underwriter/model/QuoteDao.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/QuoteDao.kt
@@ -130,6 +130,90 @@ interface QuoteDao {
 
     @SqlQuery(
         """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_apartment_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_apartment_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsBySwedishApartmentDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_house_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_house_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsBySwedishHouseDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_norwegian_home_contents_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_norwegian_home_contents_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsByNorwegianHomeContentsDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_danish_home_contents_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_danish_home_contents_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsByDanishHomeContentsDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_danish_accident_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_danish_accident_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsByDanishAccidentDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
+            SELECT DISTINCT
+            qr.master_quote_id
+            FROM quote_revision_danish_travel_data qrd
+            INNER JOIN quote_revisions qr
+            ON qrd.internal_id = qr.quote_danish_travel_data_id
+            WHERE 
+            qrd.street = :street
+            AND qrd.zip_code = :zipCode
+    """
+    )
+    fun findQuoteIdsByDanishTravelDataAddress(@Bind street: String, @Bind zipCode: String): List<UUID>
+
+    @SqlQuery(
+        """
             SELECT
             DISTINCT ON (qr.master_quote_id)
 

--- a/src/main/kotlin/com/hedvig/underwriter/model/QuoteRepository.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/QuoteRepository.kt
@@ -2,6 +2,7 @@ package com.hedvig.underwriter.model
 
 import java.time.Instant
 import java.util.UUID
+import kotlin.reflect.KClass
 
 interface QuoteRepository {
     fun find(quoteId: UUID): Quote?
@@ -13,4 +14,5 @@ interface QuoteRepository {
     fun expireQuote(id: UUID): Quote?
     fun update(updatedQuote: Quote, timestamp: Instant = Instant.now()): Quote
     fun findByContractId(contractId: UUID): Quote?
+    fun findQuotesByAddress(street: String, zipCode: String, type: KClass<*>): List<Quote>
 }

--- a/src/main/kotlin/com/hedvig/underwriter/service/RequotingService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/RequotingService.kt
@@ -1,0 +1,99 @@
+package com.hedvig.underwriter.service
+
+import com.hedvig.productPricingObjects.enums.AgreementStatus
+import com.hedvig.underwriter.model.AddressData
+import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
+import com.hedvig.underwriter.model.QuoteRepository
+import com.hedvig.underwriter.model.QuoteState
+import com.hedvig.underwriter.model.birthDateMaybe
+import com.hedvig.underwriter.model.ssnMaybe
+import com.hedvig.underwriter.service.model.PersonPolicyHolder
+import com.hedvig.underwriter.serviceIntegration.productPricing.ProductPricingService
+import com.hedvig.underwriter.util.logger
+import org.springframework.stereotype.Service
+
+@Service
+class RequotingService(
+    private val quoteRepository: QuoteRepository,
+    private val productPricingService: ProductPricingService
+) {
+
+    fun blockDueToExistingAgreement(quote: Quote): Boolean {
+        try {
+
+            logger.debug("Check if existing agreement for quote. Initiated from ${quote.initiatedFrom}")
+
+            // Do not block "internal" requests
+            if (!quote.initiatedFrom.isAnyOf(
+                    QuoteInitiatedFrom.ANDROID,
+                    QuoteInitiatedFrom.IOS,
+                    QuoteInitiatedFrom.RAPIO,
+                    QuoteInitiatedFrom.WEBONBOARDING)) {
+                return false
+            }
+
+            return hasExistingAgreement(quote)
+        } catch (e: Exception) {
+            logger.warn("Failed to check if to block due to active agreement", e)
+            return false
+        }
+    }
+
+    private fun hasExistingAgreement(quote: Quote): Boolean {
+
+        val data = quote.data
+
+        // We require ssn or birthdate to be able to identify/fingerprint customer
+        if (data !is PersonPolicyHolder<*> || (data.ssn == null && data.birthDate == null)) {
+            return false
+        }
+
+        // We require address to be able to identify/fingerprint customer
+        if (data !is AddressData || data.street == null || data.zipCode == null) {
+            return false
+        }
+
+        // Get all existing quotes user's address
+        var quotes = quoteRepository.findQuotesByAddress(data.street!!, data.zipCode!!, quote.data::class)
+
+        if (quotes.isEmpty()) {
+            return false
+        }
+
+        logger.debug("Found ${quotes.size} existing quote(s) for same address: {}", quotes.joinToString(separator = ", ") { it.id.toString() })
+
+        // Filter out all signed quotes for user's ssn and birth date having an agreement
+        quotes = quotes
+            .filter { it.state == QuoteState.SIGNED }
+            .filter { it.agreementId != null }
+            .filter { it.birthDateMaybe == quote.birthDateMaybe }
+            .filter { quote.ssnMaybe == null || it.ssnMaybe == null || it.ssnMaybe == quote.ssnMaybe }
+
+        logger.debug("Found ${quotes.size} existing signed quote(s) for same birth date/ssn: {}", quotes.joinToString(separator = ", ") { it.id.toString() })
+
+        for (existingQuote in quotes) {
+            val agreement = productPricingService.getAgreement(existingQuote.agreementId!!)
+
+            // Is agreement active?
+            val active = agreement.status.isAnyOf(
+                AgreementStatus.PENDING,
+                AgreementStatus.ACTIVE,
+                AgreementStatus.ACTIVE_IN_FUTURE
+            )
+
+            if (active) {
+                logger.info("Quote matches an already signed quote: ${existingQuote.id} with an active agreement: ${agreement.id} - ${agreement.status}")
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun QuoteInitiatedFrom.isAnyOf(vararg initiatedFrom: QuoteInitiatedFrom): Boolean =
+        initiatedFrom.any { this == it }
+
+    private fun AgreementStatus.isAnyOf(vararg statuses: AgreementStatus): Boolean =
+        statuses.any { this == it }
+}

--- a/src/main/kotlin/com/hedvig/underwriter/util/MetricsCounter.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/util/MetricsCounter.kt
@@ -1,0 +1,22 @@
+package com.hedvig.underwriter.util
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.ConcurrentHashMap
+
+open class MetricsCounter(open val registry: MeterRegistry, val name: String) {
+
+    private val counters = ConcurrentHashMap<String, Counter>()
+
+    fun increment(vararg tags: String?) {
+        val key = tags.joinToString(":")
+
+        val counter = counters[key] ?: run {
+            val counter = registry.counter(name, *tags)
+            counters[key] = counter
+            counter
+        }
+
+        counter.increment()
+    }
+}

--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateQuoteTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateQuoteTest.kt
@@ -23,10 +23,10 @@ class CreateQuoteTest {
     val strategyService = mockk<QuoteStrategyService>()
     val priceEngineService = mockk<PriceEngineService>()
     val quoteRepository = mockk<QuoteRepository>()
-    val metrics = mockk<Metrics>(relaxed = true)
+    val metrics = mockk<UnderwriterImpl.BreachedGuidelinesCounter>(relaxed = true)
 
     val cut = QuoteServiceImpl(
-        UnderwriterImpl(priceEngineService, strategyService, metrics),
+        UnderwriterImpl(priceEngineService, strategyService, mockk(relaxed = true), mockk(), metrics),
         mockk(),
         mockk(),
         quoteRepository,

--- a/src/test/kotlin/com/hedvig/underwriter/service/QuoteServiceUpdateQuotes.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/QuoteServiceUpdateQuotes.kt
@@ -26,7 +26,7 @@ class QuoteServiceUpdateQuotes {
 
         val quoteStrategyService = mockk<QuoteStrategyService>(relaxed = true)
         val cut = QuoteServiceImpl(
-            UnderwriterImpl(priceEngine, quoteStrategyService, mockk(relaxed = true)),
+            UnderwriterImpl(priceEngine, quoteStrategyService, mockk(relaxed = true), mockk(), mockk()),
             mockk(relaxed = true),
             mockk(relaxed = true),
             quoteRepository,

--- a/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
@@ -69,7 +69,7 @@ class UnderwriterImplTest {
     lateinit var priceEngineService: PriceEngineService
 
     @MockkBean(relaxed = true)
-    lateinit var metrics: Metrics
+    lateinit var metrics: UnderwriterImpl.BreachedGuidelinesCounter
 
     @Before
     fun setup() {
@@ -97,7 +97,7 @@ class UnderwriterImplTest {
     @Test
     fun successfullyCreatesSwedishApartmentQuote() {
 
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -109,7 +109,7 @@ class UnderwriterImplTest {
     @Test
     fun successfullyCreatesSwedishStudentApartmentQuote() {
         val cut = UnderwriterImpl(
-            priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics
+            priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics
         )
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "200112031356",
@@ -128,7 +128,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishHouseQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -139,7 +139,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -155,7 +155,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesNorwegianTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianTravelQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -171,7 +171,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitInvalidSwedishSsn() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(ssn = "invalid", birthDate = LocalDate.of(1912, 12, 12)).build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -184,7 +184,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitPersonalDebtCheckSwedishQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf("RED")
@@ -197,7 +197,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAgeOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(ssn = "202001010000").build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -210,7 +210,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerApartmentRulesOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             data = SwedishApartmentQuoteRequestDataBuilder(
                 householdSize = 0,
@@ -233,7 +233,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             data = SwedishApartmentQuoteRequestDataBuilder(
                 householdSize = 7,
@@ -256,7 +256,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerStudentApartmentRulesOnCreatesSwedishStudentApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "200112031356",
             data = SwedishApartmentQuoteRequestDataBuilder(
@@ -281,7 +281,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperStudentApartmentRulesOnCreatesSwedishStudentApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "198812031356",
             data = SwedishApartmentQuoteRequestDataBuilder(
@@ -307,7 +307,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerHouseRulesOnCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishHouseQuoteRequestBuilder(
             data = SwedishHouseQuoteRequestDataBuilder(
                 householdSize = 0, livingSpace = 0, yearOfConstruction = 1924,
@@ -334,7 +334,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperHouseRulesOnCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = SwedishHouseQuoteRequestBuilder(
             data = SwedishHouseQuoteRequestDataBuilder(
                 householdSize = 7, livingSpace = 251, numberOfBathrooms = 3,
@@ -366,7 +366,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder().build()
 
         every { priceEngineService.queryNorwegianHomeContentPrice(any()) } returns PriceQueryResponse(
@@ -380,7 +380,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenNorwegianSsnNotMatch() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = "24057408215"
         ).build()
@@ -402,7 +402,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeContentsQuoteWhenSsnIsNull() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = null
         ).build()
@@ -418,7 +418,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianTravelQuoteRequestBuilder().build()
 
         every { priceEngineService.queryNorwegianTravelPrice(any()) } returns PriceQueryResponse(
@@ -432,7 +432,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             data = NorwegianHomeContentsQuoteRequestDataBuilder(
                 coInsured = 6,
@@ -453,7 +453,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianHomeContentsYouthQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = "28026400734",
             birthDate = LocalDate.of(1964, 2, 28),
@@ -478,7 +478,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             data = NorwegianTravelQuoteRequestDataBuilder(
                 coInsured = 6
@@ -497,7 +497,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianTravelYouthQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             birthDate = LocalDate.now().minusYears(31).minusDays(1),
             data = NorwegianTravelQuoteRequestDataBuilder(
@@ -520,7 +520,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesDanishHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -537,7 +537,7 @@ class UnderwriterImplTest {
 
     @Test
     fun `on breached guideline verify increment counter`() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), mockk(relaxed = true), mockk(), metrics)
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             birthDate = LocalDate.now().minusYears(31).minusDays(1),
             data = NorwegianTravelQuoteRequestDataBuilder(

--- a/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplValidateAndCompleteQuoteTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplValidateAndCompleteQuoteTest.kt
@@ -17,6 +17,8 @@ class UnderwriterImplValidateAndCompleteQuoteTest {
     val cut = UnderwriterImpl(
         mockk(relaxed = true),
         quoteStrategyService,
+        mockk(relaxed = true),
+        mockk(relaxed = true),
         mockk(relaxed = true)
     )
 

--- a/src/test/kotlin/com/hedvig/underwriter/web/RequoteIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/RequoteIntegrationTest.kt
@@ -1,0 +1,444 @@
+package com.hedvig.underwriter.web
+
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.IsSsnAlreadySignedMemberResponse
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.UnderwriterQuoteSignResponse
+import com.hedvig.underwriter.serviceIntegration.notificationService.NotificationServiceClient
+import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryResponse
+import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.contract.CreateContractResponse
+import com.hedvig.underwriter.web.dtos.CompleteQuoteResponseDto
+import com.hedvig.underwriter.web.dtos.SignedQuoteResponseDto
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.javamoney.moneta.Money
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import com.hedvig.productPricingObjects.dtos.Agreement
+import com.hedvig.productPricingObjects.enums.AgreementStatus
+import com.hedvig.underwriter.serviceIntegration.memberService.MemberServiceClient
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.Flag
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.HelloHedvigResponseDto
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.PersonStatusDto
+import com.hedvig.underwriter.serviceIntegration.priceEngine.PriceEngineClient
+import com.hedvig.underwriter.serviceIntegration.productPricing.ProductPricingClient
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.junit4.SpringRunner
+import java.time.LocalDate
+import java.util.UUID
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class RequoteIntegrationTest {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @MockkBean(relaxed = true)
+    lateinit var notificationServiceClient: NotificationServiceClient
+
+    @MockkBean
+    lateinit var priceEngineClient: PriceEngineClient
+
+    @MockkBean
+    lateinit var memberServiceClient: MemberServiceClient
+
+    @MockkBean
+    lateinit var productPricingClient: ProductPricingClient
+
+    val activeAgreement = Agreement.SwedishApartment(UUID.randomUUID(), mockk(), mockk(), mockk(), null, AgreementStatus.ACTIVE, mockk(), mockk(), 0, 100)
+    val inactiveAgreement = Agreement.SwedishApartment(UUID.randomUUID(), mockk(), mockk(), mockk(), null, AgreementStatus.TERMINATED, mockk(), mockk(), 0, 100)
+
+    @Before
+    fun setup() {
+        every { memberServiceClient.personStatus(any()) } returns ResponseEntity.status(200).body(PersonStatusDto(Flag.GREEN))
+        every { memberServiceClient.checkPersonDebt(any()) } returns ResponseEntity.status(200).body(null)
+        every { memberServiceClient.checkIsSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
+        every { memberServiceClient.createMember() } returns ResponseEntity.status(200).body(HelloHedvigResponseDto("12345"))
+        every { memberServiceClient.updateMemberSsn(any(), any()) } returns Unit
+        every { memberServiceClient.signQuote(any(), any()) } returns ResponseEntity.status(200).body(UnderwriterQuoteSignResponse(1L, true))
+        every { memberServiceClient.finalizeOnBoarding(any(), any()) } returns ResponseEntity.status(200).body("")
+        every { productPricingClient.createContract(any(), any()) } returns listOf(CreateContractResponse(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()))
+        every { productPricingClient.getAgreement(any()) } returns ResponseEntity.status(200).body(activeAgreement)
+        every { priceEngineClient.queryPrice(any()) } returns PriceQueryResponse(UUID.randomUUID(), Money.of(12, "NOK"))
+    }
+
+    @Test
+    fun `Test re-quoting of SE apartment`() {
+
+        // Create a quote
+        with(createSwedishApartmentQuote<String>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // Create same quote agian, should be ok and then sign it
+        with(createSwedishApartmentQuote<CompleteQuoteResponseDto>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+
+            signQuote(body!!.id, null)
+        }
+
+        // Cannot requote a signed quote withsame address and ssn
+        with(createSwedishApartmentQuote<String>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(500)
+            assertThat(body!!).contains("Creation of quote is blocked")
+        }
+
+        // withanother ssn it should be ok
+        with(createSwedishApartmentQuote<CompleteQuoteResponseDto>(
+            ssn = "190905249801",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // withanother address it should be ok
+        with(createSwedishApartmentQuote<CompleteQuoteResponseDto>(
+            ssn = "199110112399",
+            street = "ApStreet 1",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        every { productPricingClient.getAgreement(any()) } returns ResponseEntity.status(200).body(inactiveAgreement)
+
+        // It should be ok if not an active agreement
+        with(createSwedishApartmentQuote<String>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+    }
+
+    @Test
+    fun `Test re-quoting of SE house`() {
+
+        // Create a quote
+        with(createSwedishHouseQuote<CompleteQuoteResponseDto>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // Create same quote agian, should be ok and then sign it
+        with(createSwedishHouseQuote<CompleteQuoteResponseDto>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+
+            signQuote(body!!.id, null)
+        }
+
+        // Cannot requote a signed quote withsame address and ssn
+        with(createSwedishHouseQuote<String>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(500)
+            assertThat(body!!).contains("Creation of quote is blocked")
+        }
+
+        // withanother ssn it should be ok
+        with(createSwedishHouseQuote<CompleteQuoteResponseDto>(
+            ssn = "190905249801",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // withanother address it should be ok
+        with(createSwedishHouseQuote<CompleteQuoteResponseDto>(
+            ssn = "199110112399",
+            street = "ApStreet 1",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        every { productPricingClient.getAgreement(any()) } returns ResponseEntity.status(200).body(inactiveAgreement)
+
+        // It should be ok if not an active agreement
+        with(createSwedishHouseQuote<String>(
+            ssn = "199110112399",
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+    }
+
+    @Test
+    fun `Test re-quoting of NO home content`() {
+
+        // Create a quote
+        with(createNorwegianHomeContentQuote<CompleteQuoteResponseDto>(
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // Create same quote again, should be ok and then sign it
+        with(createNorwegianHomeContentQuote<CompleteQuoteResponseDto>(
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+
+            signQuote(body!!.id, "11077941012")
+        }
+
+        // Cannot re-quote a signed quote withsame address and birthdate
+        with(createNorwegianHomeContentQuote<String>(
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(500)
+            assertThat(body!!).contains("Creation of quote is blocked")
+        }
+
+        // withanother birth date it should be ok
+        with(createNorwegianHomeContentQuote<CompleteQuoteResponseDto>(
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1971-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        // withanother address it should be ok
+        with(createNorwegianHomeContentQuote<CompleteQuoteResponseDto>(
+            street = "ApStreet 1",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+
+        every { productPricingClient.getAgreement(any()) } returns ResponseEntity.status(200).body(inactiveAgreement)
+
+        // It should be ok if not an active agreement
+        with(createNorwegianHomeContentQuote<String>(
+            street = "ApStreet 1234",
+            zip = "1234",
+            city = "ApCity",
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+    }
+
+    @Test
+    fun `Test re-quoting of NO travel`() {
+
+        // Create quote and then sign it
+        with(createNorwegianTravelQuote<CompleteQuoteResponseDto>(
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+
+            signQuote(body!!.id, "11077941012")
+        }
+
+        // Can re-quote a signed quote withsame birthdate
+        with(createNorwegianTravelQuote<String>(
+            birthdate = "1970-01-01"
+        )) {
+            assertThat(statusCode.value()).isEqualTo(200)
+        }
+    }
+
+    private inline fun <reified T : Any> createNorwegianTravelQuote(birthdate: String): ResponseEntity<T> {
+        val request = """
+            {
+                "firstName":null,
+                "lastName":null,
+                "currentInsurer":null,
+                "birthDate":"$birthdate",
+                "ssn":null,
+                "quotingPartner":"HEDVIG",
+                "productType":"TRAVEL",
+                "incompleteQuoteData":{
+                    "type":"norwegianTravel",
+                    "coInsured":1,
+                    "youth":false
+                },
+                "shouldComplete":true,
+                "underwritingGuidelinesBypassedBy":null
+            }
+        """.trimIndent()
+
+        return postJson("/_/v1/quotes", request)
+    }
+
+    private inline fun <reified T : Any> createNorwegianHomeContentQuote(birthdate: String, street: String, zip: String, city: String): ResponseEntity<T> {
+        val request = """
+            {
+                "firstName": null,
+                "lastName": null,
+                "currentInsurer": null,
+                "birthDate": "$birthdate",
+                "ssn": null,
+                "quotingPartner": "HEDVIG",
+                "productType": "HOME_CONTENT",
+                "incompleteQuoteData": {
+                    "type": "norwegianHomeContents",
+                    "street": "$street",
+                    "zipCode": "$zip",
+                    "city": "$city",
+                    "livingSpace": 111,
+                    "coInsured": 1,
+                    "youth": false,
+                    "subType": "OWN"
+                },
+                "shouldComplete": true,
+                "underwritingGuidelinesBypassedBy": null
+            }
+        """.trimIndent()
+
+        return postJson("/_/v1/quotes", request)
+    }
+
+    private inline fun <reified T : Any> createSwedishApartmentQuote(ssn: String, street: String, zip: String, city: String): ResponseEntity<T> {
+        val request = """           
+            {
+                "firstName": null,
+                "lastName": null,
+                "currentInsurer": null,
+                "birthDate": null,
+                "ssn": "$ssn",
+                "quotingPartner": "HEDVIG",
+                "productType": "APARTMENT",
+                "incompleteQuoteData": {
+                    "type": "apartment",
+                    "street": "$street",
+                    "zipCode": "$zip",
+                    "city": "$city",
+                    "livingSpace": 111,
+                    "householdSize": 1,
+                    "floor": 0,
+                    "subType": "BRF"
+                },
+                "shouldComplete": true
+            }
+        """.trimIndent()
+
+        return postJson("/_/v1/quotes", request)
+    }
+
+    private inline fun <reified T : Any> createSwedishHouseQuote(ssn: String, street: String, zip: String, city: String): ResponseEntity<T> {
+        val request = """           
+            {
+                "firstName": null,
+                "lastName": null,
+                "currentInsurer": null,
+                "birthDate": null,
+                "ssn": "$ssn",
+                "quotingPartner": "HEDVIG",
+                "productType": "HOUSE",
+                "incompleteQuoteData": {
+                    "type": "house",
+                    "street": "$street",
+                    "zipCode": "$zip",
+                    "city": "$city",
+                    "livingSpace": 111,
+                    "householdSize": 1,
+                    "ancillaryArea": 11,
+                    "yearOfConstruction": 1970,
+                    "numberOfBathrooms": 1,
+                    "extraBuildings": [{
+                        "id": null,
+                        "type": "CARPORT",
+                        "area": 11,
+                        "hasWaterConnected": true
+                    }],
+                    "floor": 0,
+                    "subleted": false
+                },
+                "shouldComplete": true
+            }
+        """.trimIndent()
+
+        return postJson("/_/v1/quotes", request)
+    }
+
+    private fun signQuote(quoteId: UUID, ssn: String?): ResponseEntity<SignedQuoteResponseDto> {
+
+        val ssnString = if (ssn != null) "\"$ssn\"" else "null"
+
+        val request = """
+            {
+                "name": {
+                    "firstName": "Apan",
+                    "lastName": "Apansson"
+                },
+                "ssn": $ssnString,
+                "startDate": "${LocalDate.now()}",
+                "email": "apan@apansson.se"
+            }
+        """.trimIndent()
+
+        return postJson("/_/v1/quotes/$quoteId/sign", request)
+    }
+
+    private inline fun <reified T : Any> postJson(url: String, data: String): ResponseEntity<T> {
+
+        val headers = HttpHeaders()
+        headers.accept = listOf(MediaType.APPLICATION_JSON)
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        return restTemplate.exchange(url, HttpMethod.POST, HttpEntity(data, headers), T::class.java)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,5 +4,11 @@ spring:
   main:
     allow-bean-definition-overriding: true
 
+  profiles:
+    active: development
+
 graphcms.project: Underwriter
 graphcms.url: empty
+
+features:
+  block-requoting: true


### PR DESCRIPTION
# Jira Issue: [IPC-67] 

## What?
Introduced blocking for customers to create quotes if already having an active agreement.

Address / birthday / ssn is used to identify if quote request is originating from a customer with an active agreement. 

All existing insurance types are supported except for Norwegian travel that has no address information or other info to make it possible to identify customer.

The blockings are registered with a metrics counter and is visible in DataDog.

**NOTE**: This feature will be deployed with a feature flag to initially not block any requests, but just to log identified re-quotings to make sure it is safe to do the blocking.

## Why?
Prices is going to be changed for SE on 1:st of April. To avoid unhappy customers (and headache for IEX) we are not going to serve quotes for customers already having an active agreement.

## Optional checklist
- [x] Codescouted
- [x] Unit tests written
- [x] Tested locally

