### PR TITLE
Disable blocking creating quotes for customers with active an agreement in staging.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,10 @@ lokalise:
 hedvig:
   notification-service.url: http://notification-service
 
+---
+spring:
+  profiles: production
+
 features:
   block-requoting: true
 
@@ -62,6 +66,9 @@ spring:
 graphql:
   servlet:
     exception-handlers-enabled: true
+
+features:
+  block-requoting: false
 
 ---
 spring:


### PR DESCRIPTION
Disable the feature to block creating quotes for customers already having a signed agreement.

This since it makes it cumbersome to do testing in stage.