### PR TITLE
Feature/partner campaign code

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/service/SignService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/SignService.kt
@@ -8,7 +8,6 @@ import com.hedvig.underwriter.web.dtos.ErrorResponseDto
 import com.hedvig.underwriter.web.dtos.SignQuoteFromHopeRequest
 import com.hedvig.underwriter.web.dtos.SignQuoteRequestDto
 import com.hedvig.underwriter.web.dtos.SignQuotesRequestDto
-import com.hedvig.underwriter.web.dtos.SignRequest
 import com.hedvig.underwriter.web.dtos.SignedQuoteResponseDto
 import java.util.UUID
 
@@ -36,11 +35,9 @@ interface SignService {
     ): List<SignedQuoteResponseDto>
 
     fun signQuoteFromHope(
-        completeQuoteId: UUID,
+        quoteId: UUID,
         request: SignQuoteFromHopeRequest
     ): Either<ErrorResponseDto, SignedQuoteResponseDto>
-
-    fun memberSigned(memberId: String, signedRequest: SignRequest)
 
     fun getSignMethodFromQuotes(quoteIds: List<UUID>): SignMethod
 }

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/ChooseActiveFromDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/ChooseActiveFromDto.kt
@@ -1,7 +1,0 @@
-package com.hedvig.underwriter.web.dtos
-
-import java.time.LocalDateTime
-
-data class ChooseActiveFromDto(
-    val activeFrom: LocalDateTime
-)

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/IncompleteQuoteResponseDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/IncompleteQuoteResponseDto.kt
@@ -1,7 +1,0 @@
-package com.hedvig.underwriter.web.dtos
-
-import java.util.UUID
-
-data class IncompleteQuoteResponseDto(
-    val id: UUID
-)

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
@@ -8,5 +8,6 @@ data class SignQuoteRequestDto(
     @Masked val name: Name?,
     @Masked val ssn: String?,
     val startDate: LocalDate?,
-    @Masked val email: String
+    @Masked val email: String,
+    val partnerCampaignCode: String?
 )

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
@@ -12,16 +12,20 @@ data class SignQuotesRequestDto(
     @Masked val ssn: String?,
     val startDate: LocalDate?,
     @Masked val email: String,
-    val price: BigDecimal? = null, // Used for bundle verification
-    val currency: String? = null
+    val price: BigDecimal?, // Used for bundle verification
+    val currency: String?,
+    val partnerCampaignCode: String?
 ) {
     companion object {
         fun from(quoteId: UUID, request: SignQuoteRequestDto): SignQuotesRequestDto = SignQuotesRequestDto(
-            listOf(quoteId),
-            request.name,
-            request.ssn,
-            request.startDate,
-            request.email
+            quoteIds = listOf(quoteId),
+            name = request.name,
+            ssn = request.ssn,
+            startDate = request.startDate,
+            email = request.email,
+            price = null,
+            currency = null,
+            partnerCampaignCode = request.partnerCampaignCode
         )
     }
 }

--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
@@ -18,7 +18,6 @@ import com.hedvig.underwriter.testhelp.JdbiRule
 import com.hedvig.underwriter.testhelp.databuilder.quote
 import com.hedvig.underwriter.web.dtos.SignQuoteFromHopeRequest
 import com.hedvig.underwriter.web.dtos.SignQuoteRequestDto
-import com.hedvig.underwriter.web.dtos.SignRequest
 import io.mockk.every
 import io.mockk.mockk
 import org.jdbi.v3.jackson2.Jackson2Config
@@ -45,42 +44,6 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
         quoteRepository = QuoteRepositoryImpl(jdbiRule.jdbi)
         productPricingService = mockk()
         memberService = mockk()
-    }
-
-    @Test
-    fun `memberSigned saves contractId`() {
-        val quoteId = UUID.randomUUID()
-        quoteRepository.insert(
-            quote {
-                id = quoteId
-                memberId = "1337"
-                initiatedFrom = QuoteInitiatedFrom.IOS
-            }
-        )
-
-        val signServiceImpl = SignServiceImpl(
-            mockk(),
-            mockk(),
-            quoteRepository,
-            mockk(),
-            productPricingService,
-            mockk(),
-            mockk(),
-            mockk()
-        )
-
-        val contractId = UUID.randomUUID()
-        every { productPricingService.createContractsFromQuotes(any(), any(), any()) } returns listOf(
-            CreateContractResponse(quoteId, UUID.randomUUID(), contractId)
-        )
-
-        signServiceImpl.memberSigned(
-            "1337", SignRequest(
-                "referenceToken", signature = "", oscpResponse = ""
-            )
-        )
-
-        assertThat(quoteRepository.find(quoteId)!!.contractId).isEqualTo(contractId)
     }
 
     @Test
@@ -115,7 +78,11 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
         signServiceImpl.signQuoteFromRapio(
             quoteId,
             SignQuoteRequestDto(
-                Name("Mr Test", "Tester"), null, LocalDate.of(2020, 1, 1), "a@email.com"
+                name = Name("Mr Test", "Tester"),
+                ssn = null,
+                startDate = LocalDate.of(2020, 1, 1),
+                email = "a@email.com",
+                partnerCampaignCode = null
             )
         )
 

--- a/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
@@ -135,7 +135,15 @@ class SignServiceImplTest {
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
 
-        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), "null"))
+        cut.signQuoteFromRapio(
+            quoteId, SignQuoteRequestDto(
+                name = Name(firstName = "", lastName = ""),
+                ssn = null,
+                startDate = LocalDate.now(),
+                email = "null",
+                partnerCampaignCode = null
+            )
+        )
         verify { customerIO.postSignUpdate(ofType(Quote::class)) }
     }
 
@@ -164,7 +172,13 @@ class SignServiceImplTest {
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
 
-        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), "null"))
+        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(
+            name = Name(firstName = "", lastName = ""),
+            ssn = null,
+            startDate = LocalDate.now(),
+            email = "null",
+            partnerCampaignCode = null
+        ))
         verify { customerIO.postSignUpdate(any()) }
     }
 


### PR DESCRIPTION
# Jira Issue: [MX-87] 

## What?
- Add ability to pass campaignCode as a partner `partnerCampaignCode`
- Remove some deprecated endpoints+dtos (checked usage here https://app.datadoghq.eu/apm/service/underwriter/servlet.request?end=1619617270896&env=prod&paused=false&start=1619012470896) 

## Why?
- For Avy partnership and other comparison sites to allow for different campaigns

## Outstanding
- How should the campaign codes be managed, currently we cannot create partners from Hope?
- How do we enforce that partners only redeem codes they are allowed to redeem?

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [ ] Tested locally



[MX-87]: https://hedvig.atlassian.net/browse/MX-87