### PR TITLE
Deleting any sign sessions before deleting a quote

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/model/QuoteRepositoryImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/QuoteRepositoryImpl.kt
@@ -215,6 +215,11 @@ class QuoteRepositoryImpl(private val jdbi: Jdbi) : QuoteRepository {
 
     override fun delete(quote: Quote) {
         jdbi.inTransaction<Unit, RuntimeException> { h ->
+
+            // Delete any sessions for quote first, due to the FK
+            val sessionDao = h.attach<SignSessionDao>()
+            sessionDao.delete(quote.id)
+
             val dao = h.attach<QuoteDao>()
             val revs = dao.findRevisions(quote.id)
 

--- a/src/main/kotlin/com/hedvig/underwriter/model/SignSessionDao.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/SignSessionDao.kt
@@ -40,4 +40,12 @@ interface SignSessionDao {
         """
     )
     fun find(sessionId: UUID): List<UUID>
+
+    @SqlUpdate(
+        """
+                DELETE FROM sign_session_master_quote 
+                WHERE master_quote_id = :quoteId
+            """
+    )
+    fun delete(@Bind quoteId: UUID)
 }


### PR DESCRIPTION
We have a FK constraint that needs to be taken care of before we can delete a quote.
