### PR TITLE
expose the type of the extrabuilding so that the web frontend can use it when editing quotes

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/ExtraBuildingValue.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/ExtraBuildingValue.kt
@@ -1,7 +1,15 @@
 package com.hedvig.underwriter.graphql.type
 
-data class ExtraBuildingValue(
-    val area: Int,
-    val displayName: String,
+interface ExtraBuildingCore {
+    val type: ExtraBuildingType
+    val area: Int
+    val displayName: String
     val hasWaterConnected: Boolean
-)
+}
+
+data class ExtraBuildingValue(
+    override val type: ExtraBuildingType,
+    override val area: Int,
+    override val displayName: String,
+    override val hasWaterConnected: Boolean
+) : ExtraBuildingCore

--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
@@ -228,6 +228,7 @@ class QuoteMapper(
         extraBuilding: ExtraBuilding,
         locale: Locale
     ): ExtraBuildingValue = ExtraBuildingValue(
+        type = com.hedvig.underwriter.graphql.type.ExtraBuildingType.valueOf(extraBuilding.type.name),
         area = extraBuilding.area,
         hasWaterConnected = extraBuilding.hasWaterConnected,
         displayName = extractDisplayName(extraBuilding.type, locale)

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -346,12 +346,14 @@ type CurrentInsurer {
 union ExtraBuilding = ExtraBuildingValue
 
 interface ExtraBuildingCore {
+    type: ExtraBuildingType!
     area: Int!
     displayName: String!
     hasWaterConnected: Boolean!
 }
 
 type ExtraBuildingValue implements ExtraBuildingCore {
+    type: ExtraBuildingType!
     area: Int!
     displayName: String!
     hasWaterConnected: Boolean!


### PR DESCRIPTION
# Jira Issue: [MX-140]

## What?
- Expose the type in the graphql types 

## Why?
- https://hedviginsurance.slack.com/archives/C01PBA9H9QB/p1621427401000100?thread_ts=1620805512.001000&cid=C01PBA9H9QB

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally



[MX-140]: https://hedvig.atlassian.net/browse/MX-140