### PR TITLE
Added missing fk indexes

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.yml
+++ b/src/main/resources/db/changelog/changelog-master.yml
@@ -95,3 +95,6 @@ databaseChangeLog:
   - include:
       file: ./migrations/20210512-1557-add-indexes.sql
       relativeToChangelogFile: true
+  - include:
+      file: ./migrations/20210520-1557-add-missing-fk-indexes.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/migrations/20210520-1557-add-missing-fk-indexes.sql
+++ b/src/main/resources/db/changelog/migrations/20210520-1557-add-missing-fk-indexes.sql
@@ -1,0 +1,25 @@
+--liquibase formatted.sql
+
+--changeset ostenforshed:20210520-1557-add-missing-fk-indexes.sql
+
+CREATE INDEX idx_quote_revisions_master_quote_id ON quote_revisions(master_quote_id);
+CREATE INDEX idx_quote_revisions_quote_apartment_data_id ON quote_revisions(quote_apartment_data_id);
+CREATE INDEX idx_quote_revisions_quote_danish_accident_data_id ON quote_revisions(quote_danish_accident_data_id);
+CREATE INDEX idx_quote_revisions_quote_danish_home_contents_data_id ON quote_revisions(quote_danish_home_contents_data_id);
+CREATE INDEX idx_quote_revisions_quote_danish_travel_data_id ON quote_revisions(quote_danish_travel_data_id);
+CREATE INDEX idx_quote_revisions_quote_house_data_id ON quote_revisions(quote_house_data_id);
+CREATE INDEX idx_quote_revisions_quote_norwegian_home_contents_data_id ON quote_revisions(quote_norwegian_home_contents_data_id);
+CREATE INDEX idx_quote_revisions_quote_norwegian_travel_data_id ON quote_revisions(quote_norwegian_travel_data_id);
+CREATE INDEX sign_session_master_quote_master_quote_id ON sign_session_master_quote(master_quote_id);
+CREATE INDEX quote_line_item_revision_id ON quote_line_item(revision_id);
+
+--rollback DROP INDEX idx_quote_revisions_master_quote_id
+--rollback DROP INDEX idx_quote_revisions_quote_apartment_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_danish_accident_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_danish_home_contents_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_danish_travel_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_house_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_norwegian_home_contents_data_id
+--rollback DROP INDEX idx_quote_revisions_quote_norwegian_travel_data_id
+--rollback DROP INDEX sign_session_master_quote_master_quote_id
+--rollback DROP INDEX quote_line_item_revision_id


### PR DESCRIPTION
Discovered that we do not have any indexes on our foreign key columns. This is something that is automatically created in MySQL but not in Postgres:

https://www.cybertec-postgresql.com/en/index-your-foreign-key/

This will hopefully speed up some queries and deletes a bit.

