### PR TITLE
Feat/competitor price

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -571,6 +571,18 @@ data class Quote(
         is DanishTravelData -> ZoneId.of("Europe/Copenhagen")
     }
 
+    fun getLivingArea(): Int? {
+        return when (this.data) {
+            is SwedishHouseData -> this.data.livingSpace
+            is SwedishApartmentData -> this.data.livingSpace
+            is NorwegianHomeContentsData -> this.data.livingSpace
+            is DanishHomeContentsData -> this.data.livingSpace
+            is DanishAccidentData,
+            is DanishTravelData,
+            is NorwegianTravelData -> null
+        }
+    }
+
     companion object {
         private const val SEK = "SEK"
         private const val NOK = "NOK"

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupService.kt
@@ -1,0 +1,8 @@
+package com.hedvig.underwriter.serviceIntegration.lookupService
+
+import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
+
+interface LookupService {
+    fun getMatchingCompetitorPrice(quote: Quote): CompetitorPricing?
+}

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupServiceClient.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupServiceClient.kt
@@ -1,0 +1,28 @@
+package com.hedvig.underwriter.serviceIntegration.lookupService
+
+import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
+import feign.Headers
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
+import java.util.UUID
+import javax.validation.Valid
+
+@Headers("Accept: application/json;charset=utf-8")
+@FeignClient(
+    name = "lookupServiceClient",
+    url = "\${hedvig.lookup-service.url:lookup-service}"
+)
+@Component
+interface LookupServiceClient {
+    @GetMapping("/_/insurely/{clientReferenceId}/monthlyPremiumData")
+    fun getMatchingCompetitorPrice(
+        @PathVariable @Valid clientReferenceId: UUID,
+        @RequestParam @Valid marketCurrency: String?,
+        @RequestParam @Valid insuranceType: String?
+
+    ): ResponseEntity<CompetitorPricing>
+}

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/LookupServiceImpl.kt
@@ -1,0 +1,99 @@
+package com.hedvig.underwriter.serviceIntegration.lookupService
+
+import com.hedvig.underwriter.model.AddressData
+import com.hedvig.underwriter.model.DanishHomeContentsData
+import com.hedvig.underwriter.model.NorwegianHomeContentsData
+import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.model.SwedishApartmentData
+import com.hedvig.underwriter.model.SwedishHouseData
+import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
+import com.hedvig.underwriter.util.logger
+import org.springframework.stereotype.Service
+
+@Service
+class LookupServiceImpl(
+    val lookupServiceClient: LookupServiceClient
+) : LookupService {
+
+    private val TYPE_HOUSE = "houseContentInsurance"
+    private val STREET_AND_BR_REGEX = "\\D+\\d+".toRegex()
+
+    override fun getMatchingCompetitorPrice(quote: Quote): CompetitorPricing? {
+        try {
+
+            val insuranceType = getInsuranceType(quote) ?: return null
+
+            val response = lookupServiceClient.getMatchingCompetitorPrice(quote.dataCollectionId!!,
+                quote.currencyWithFallbackOnMarket, insuranceType
+            )
+
+            if (response.statusCode.is2xxSuccessful) {
+
+                // Ensure the found competitor price matches the quote details
+                if (isMatching(quote, response.body!!)) {
+                    return response.body
+                } else {
+                    return null
+                }
+            }
+        } catch (exception: Exception) {
+            logger.error("Something went wrong when fetching MonthlyPremiumData from lookup service ${exception.message}")
+        }
+        return null
+    }
+
+    private fun isMatching(quote: Quote, response: CompetitorPricing): Boolean {
+
+        val livingAreaMatches = (response.livingArea != null && response.livingArea == quote.getLivingArea())
+        val postalCodeMatches =
+            (response.postalCode != null && response.postalCode == (quote.data as AddressData).zipCode)
+
+        if (livingAreaMatches || postalCodeMatches) {
+            logger.info("LivingArea($livingAreaMatches) or postalCode($postalCodeMatches) matches, so we're assuming this is the same object")
+            return true
+        } else {
+            // Do some logging only, so we can evaluate
+            if (streetAddressMatches(quote, response)) {
+                logger.info("(Test) Street and number matched, but not postalCode/livingArea. quoteId: ${quote.id}, dataCollectionId: ${quote.dataCollectionId}")
+            }
+
+            return false
+        }
+    }
+
+    private fun getInsuranceType(quote: Quote): String? {
+
+        return when (quote.data) {
+            is SwedishApartmentData,
+            is SwedishHouseData,
+            is NorwegianHomeContentsData,
+            is DanishHomeContentsData
+            -> TYPE_HOUSE
+
+            else -> {
+                logger.warn("Unexpected insurance type, for getting competiror pricing")
+                null
+            }
+        }
+    }
+
+    private fun streetAddressMatches(quote: Quote, competitorPricing: CompetitorPricing): Boolean {
+
+        // Basic matching test of SE addresses, if the street+nunber is contained within our address
+        val quoteStreet = (quote.data as AddressData).street
+        val competitorHolderAddress = competitorPricing.insuranceObjectAddress
+
+        if (quoteStreet != null && competitorHolderAddress != null) {
+
+            val streetAndNumber = STREET_AND_BR_REGEX.find(competitorHolderAddress)
+
+            if (streetAndNumber != null) {
+                if (quoteStreet.contains(streetAndNumber.value, true)) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+}

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/dtos/CompetitorPricing.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/lookupService/dtos/CompetitorPricing.kt
@@ -1,0 +1,13 @@
+package com.hedvig.underwriter.serviceIntegration.lookupService.dtos
+
+import javax.money.MonetaryAmount
+
+data class CompetitorPricing(
+    val monthlyNetPremium: MonetaryAmount,
+    val monthlyGrossPremium: MonetaryAmount,
+    val monthlyDiscount: MonetaryAmount,
+    val insuranceObjectAddress: String?,
+    val postalCode: String?,
+    val livingArea: Int?,
+    val numberInsured: Int?
+)

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/CompetitorPrice.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/CompetitorPrice.kt
@@ -1,0 +1,18 @@
+package com.hedvig.underwriter.serviceIntegration.priceEngine.dtos
+
+import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
+import java.math.BigDecimal
+
+data class CompetitorPrice(val price: BigDecimal, val numberInsured: Int?) {
+
+    companion object {
+
+        fun from(competitorPricing: CompetitorPricing?): CompetitorPrice? {
+            return if (competitorPricing != null)
+                CompetitorPrice(
+                    competitorPricing.monthlyGrossPremium.number.numberValueExact(BigDecimal::class.java),
+                    competitorPricing.numberInsured)
+            else null
+        }
+    }
+}

--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateQuoteTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateQuoteTest.kt
@@ -12,6 +12,7 @@ import com.hedvig.underwriter.model.QuoteRepository
 import com.hedvig.underwriter.service.guidelines.BaseGuideline
 import com.hedvig.underwriter.service.guidelines.BreachedGuidelineCode
 import com.hedvig.underwriter.service.quoteStrategies.QuoteStrategyService
+import com.hedvig.underwriter.serviceIntegration.lookupService.LookupService
 import com.hedvig.underwriter.serviceIntegration.priceEngine.PriceEngineService
 import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryRequest
 import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryResponse
@@ -30,11 +31,12 @@ class CreateQuoteTest {
     val strategyService = mockk<QuoteStrategyService>()
     val priceEngineService = mockk<PriceEngineService>()
     val quoteRepository = mockk<QuoteRepository>()
+    val lookupService = mockk<LookupService>()
     val requotingService = RequotingServiceImpl(mockk(relaxed = true), mockk())
     val metrics = mockk<UnderwriterImpl.BreachedGuidelinesCounter>(relaxed = true)
 
     val cut = QuoteServiceImpl(
-        UnderwriterImpl(priceEngineService, strategyService, requotingService, mockk(), metrics),
+        UnderwriterImpl(priceEngineService, strategyService, requotingService, mockk(), metrics, lookupService),
         mockk(),
         mockk(),
         quoteRepository,

--- a/src/test/kotlin/com/hedvig/underwriter/service/QuoteServiceUpdateQuotesTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/QuoteServiceUpdateQuotesTest.kt
@@ -27,7 +27,7 @@ class QuoteServiceUpdateQuotesTest {
         val quoteStrategyService = mockk<QuoteStrategyService>(relaxed = true)
 
         val cut = QuoteServiceImpl(
-            UnderwriterImpl(priceEngine, quoteStrategyService, requotingService, mockk(), mockk()),
+            UnderwriterImpl(priceEngine, quoteStrategyService, requotingService, mockk(), mockk(), mockk()),
             mockk(relaxed = true),
             mockk(relaxed = true),
             quoteRepository,

--- a/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
@@ -77,7 +77,7 @@ class UnderwriterImplTest {
     @Test
     fun successfullyCreatesSwedishApartmentQuote() {
 
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics,  mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -89,7 +89,7 @@ class UnderwriterImplTest {
     @Test
     fun successfullyCreatesSwedishStudentApartmentQuote() {
         val cut = UnderwriterImpl(
-            priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics
+            priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk()
         )
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "200112031356",
@@ -108,7 +108,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishHouseQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -119,7 +119,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -135,7 +135,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesNorwegianTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianTravelQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -151,7 +151,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitInvalidSwedishSsn() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(ssn = "invalid", birthDate = LocalDate.of(1912, 12, 12)).build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -164,7 +164,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitPersonalDebtCheckSwedishQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf("RED")
@@ -177,7 +177,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAgeOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(ssn = "202001010000").build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()
@@ -190,7 +190,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerApartmentRulesOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             data = SwedishApartmentQuoteRequestDataBuilder(
                 householdSize = 0,
@@ -213,7 +213,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesSwedishApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             data = SwedishApartmentQuoteRequestDataBuilder(
                 householdSize = 7,
@@ -236,7 +236,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerStudentApartmentRulesOnCreatesSwedishStudentApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "200112031356",
             data = SwedishApartmentQuoteRequestDataBuilder(
@@ -261,7 +261,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperStudentApartmentRulesOnCreatesSwedishStudentApartmentQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder(
             ssn = "198812031356",
             data = SwedishApartmentQuoteRequestDataBuilder(
@@ -287,7 +287,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllLowerHouseRulesOnCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishHouseQuoteRequestBuilder(
             data = SwedishHouseQuoteRequestDataBuilder(
                 householdSize = 0, livingSpace = 0, yearOfConstruction = 1924,
@@ -314,7 +314,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperHouseRulesOnCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishHouseQuoteRequestBuilder(
             data = SwedishHouseQuoteRequestDataBuilder(
                 householdSize = 7, livingSpace = 251, numberOfBathrooms = 3,
@@ -346,7 +346,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitTOO_MUCH_LIVING_SPACEOnCreatesSwedishHouseQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishHouseQuoteRequestBuilder(
             data = SwedishHouseQuoteRequestDataBuilder(
                 householdSize = 1,
@@ -373,7 +373,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder().build()
 
         every { priceEngineService.queryNorwegianHomeContentPrice(any()) } returns PriceQueryResponse(
@@ -387,7 +387,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenNorwegianSsnNotMatch() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = "24057408215"
         ).build()
@@ -409,7 +409,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeContentsQuoteWhenSsnIsNull() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = null
         ).build()
@@ -425,7 +425,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreateNorwegianHomeTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianTravelQuoteRequestBuilder().build()
 
         every { priceEngineService.queryNorwegianTravelPrice(any()) } returns PriceQueryResponse(
@@ -439,7 +439,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             data = NorwegianHomeContentsQuoteRequestDataBuilder(
                 coInsured = 6,
@@ -460,7 +460,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianHomeContentsYouthQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianHomeContentsQuoteRequestBuilder(
             ssn = "28026400734",
             birthDate = LocalDate.of(1964, 2, 28),
@@ -485,7 +485,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianTravelQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             data = NorwegianTravelQuoteRequestDataBuilder(
                 coInsured = 6
@@ -504,7 +504,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitAllUpperApartmentRulesOnCreatesNorwegianTravelYouthQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             birthDate = LocalDate.now().minusYears(31).minusDays(1),
             data = NorwegianTravelQuoteRequestDataBuilder(
@@ -527,7 +527,7 @@ class UnderwriterImplTest {
 
     @Test
     fun `on breached guideline verify increment counter`() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = NorwegianTravelQuoteRequestBuilder(
             birthDate = LocalDate.now().minusYears(31).minusDays(1),
             data = NorwegianTravelQuoteRequestDataBuilder(
@@ -543,7 +543,7 @@ class UnderwriterImplTest {
 
     @Test
     fun successfullyCreatesDanishHomeContentsQuote() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder().build()
         val quoteId = UUID.randomUUID()
 
@@ -560,7 +560,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishSsnNotMatch() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             ssn = "0411357627",
             birthDate = LocalDate.of(1964, 11, 4)
@@ -584,7 +584,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishUnderage() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             ssn = "1110137970",
             birthDate = LocalDate.of(2013, 1, 11)
@@ -608,7 +608,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishInvalidSsn() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             ssn = "04113576261234",
             birthDate = LocalDate.of(1935, 11, 4)
@@ -632,7 +632,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentCoInsuredToLow() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 coInsured = -1
@@ -657,7 +657,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentStudentCoInsuredAndAgeTooHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 isStudent = true,
@@ -684,7 +684,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentCoInsuredRegularToHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 coInsured = 7
@@ -709,7 +709,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentLivingSpaceTooLow() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 livingSpace = 4
@@ -734,7 +734,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentStudentLivingSpaceAndAgeTooHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 isStudent = true,
@@ -761,7 +761,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishHomeContentLivingSpaceRegularTooHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishHomeContentsQuoteRequestBuilder(
             data = DanishHomeContentsQuoteRequestDataBuilder(
                 livingSpace = 251
@@ -786,7 +786,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishAccidentStudentCoInsuredAndAgeToHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishAccidentQuoteRequestBuilder(
             data = DanishAccidentQuoteRequestDataBuilder(
                 isStudent = true,
@@ -813,7 +813,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishRegularAccidentCoInsuredTooHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishAccidentQuoteRequestBuilder(
             data = DanishAccidentQuoteRequestDataBuilder(
                 coInsured = 7
@@ -838,7 +838,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishTravelStudentCoInsuredAndAgeToHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishTravelQuoteRequestBuilder(
             data = DanishTravelQuoteRequestDataBuilder(
                 isStudent = true,
@@ -865,7 +865,7 @@ class UnderwriterImplTest {
 
     @Test
     fun underwritingGuidelineHitWhenDanishRegularTravelCoInsuredTooHigh() {
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics)
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = DanishTravelQuoteRequestBuilder(
             data = DanishTravelQuoteRequestDataBuilder(
                 coInsured = 7

--- a/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplValidateAndCompleteQuoteTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplValidateAndCompleteQuoteTest.kt
@@ -21,6 +21,7 @@ class UnderwriterImplValidateAndCompleteQuoteTest {
         quoteStrategyService,
         mockk(relaxed = true),
         mockk(relaxed = true),
+        mockk(relaxed = true),
         mockk(relaxed = true)
     )
 

--- a/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
@@ -36,7 +36,8 @@ class QuoteClient {
         city: String = "ApCity",
         livingSpace: Int = 111,
         householdSize: Int = 1,
-        subType: String = "BRF"
+        subType: String = "BRF",
+        dataCollectionId: UUID? = null
     ): CompleteQuoteResponseDto {
         return createSwedishApartmentQuote<CompleteQuoteResponseDto>(
             firstName,
@@ -51,7 +52,8 @@ class QuoteClient {
             city,
             livingSpace,
             householdSize,
-            subType
+            subType,
+            dataCollectionId
         ).body!!
     }
 
@@ -492,7 +494,8 @@ class QuoteClient {
         city: String,
         livingSpace: Int,
         householdSize: Int,
-        subType: String
+        subType: String,
+        dataCollectionId: UUID? = null
     ): ResponseEntity<T> {
         val request = """           
             {
@@ -506,6 +509,7 @@ class QuoteClient {
                 "memberId": ${getNullableString(memberId)},
                 "quotingPartner": "HEDVIG",
                 "productType": "APARTMENT",
+                "dataCollectionId": ${dataCollectionId?.let { "\"$it\"" } ?: "null"},
                 "incompleteQuoteData": {
                     "type": "apartment",
                     "street": "$street",

--- a/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
@@ -1,0 +1,243 @@
+package com.hedvig.underwriter.web
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import com.hedvig.productPricingObjects.dtos.Agreement
+import com.hedvig.productPricingObjects.enums.AgreementStatus
+import com.hedvig.underwriter.serviceIntegration.lookupService.LookupServiceClient
+import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
+import com.hedvig.underwriter.serviceIntegration.memberService.MemberServiceClient
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.Flag
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.HelloHedvigResponseDto
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.IsSsnAlreadySignedMemberResponse
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.PersonStatusDto
+import com.hedvig.underwriter.serviceIntegration.memberService.dtos.UnderwriterQuoteSignResponse
+import com.hedvig.underwriter.serviceIntegration.notificationService.NotificationServiceClient
+import com.hedvig.underwriter.serviceIntegration.priceEngine.PriceEngineClient
+import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryRequest
+import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryResponse
+import com.hedvig.underwriter.serviceIntegration.productPricing.ProductPricingClient
+import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.contract.CreateContractResponse
+import com.hedvig.underwriter.testhelp.QuoteClient
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.javamoney.moneta.Money
+import org.jdbi.v3.core.Jdbi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.junit4.SpringRunner
+import java.util.UUID
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CompetitorPriceIntegrationTest {
+
+    @Autowired
+    private lateinit var jdbi: Jdbi
+
+    @Autowired
+    private lateinit var quoteClient: QuoteClient
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @MockkBean(relaxed = true)
+    lateinit var notificationServiceClient: NotificationServiceClient
+
+    @MockkBean
+    lateinit var priceEngineClient: PriceEngineClient
+
+    @MockkBean
+    lateinit var memberServiceClient: MemberServiceClient
+
+    @MockkBean
+    lateinit var productPricingClient: ProductPricingClient
+
+    @MockkBean
+    lateinit var lookupServiceClient: LookupServiceClient
+
+    val activeAgreement = Agreement.SwedishApartment(UUID.randomUUID(),
+        mockk(),
+        mockk(),
+        mockk(),
+        null,
+        AgreementStatus.ACTIVE,
+        mockk(),
+        mockk(),
+        0,
+        100)
+
+    @Before
+    fun setup() {
+        every { memberServiceClient.personStatus(any()) } returns ResponseEntity.status(200)
+            .body(PersonStatusDto(Flag.GREEN))
+        every { memberServiceClient.checkPersonDebt(any()) } returns ResponseEntity.status(200).body(null)
+        every { memberServiceClient.checkIsSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(
+            false)
+        every { memberServiceClient.createMember() } returns ResponseEntity.status(200)
+            .body(HelloHedvigResponseDto("12345"))
+        every { memberServiceClient.updateMemberSsn(any(), any()) } returns Unit
+        every { memberServiceClient.signQuote(any(), any()) } returns ResponseEntity.status(200)
+            .body(UnderwriterQuoteSignResponse(1L, true))
+        every { memberServiceClient.finalizeOnBoarding(any(), any()) } returns ResponseEntity.status(200).body("")
+        every {
+            productPricingClient.createContract(any(),
+                any())
+        } returns listOf(CreateContractResponse(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()))
+        every { productPricingClient.getAgreement(any()) } returns ResponseEntity.status(200).body(activeAgreement)
+        every { priceEngineClient.queryPrice(any()) } returns PriceQueryResponse(UUID.randomUUID(), Money.of(12, "NOK"))
+    }
+
+    @Test
+    fun `Test quoting with competitor price`() {
+
+        val priceRequestSlot = slot<PriceQueryRequest>()
+        every { priceEngineClient.queryPrice(capture(priceRequestSlot)) } returns PriceQueryResponse(UUID.randomUUID(),
+            Money.of(99, "SEK"))
+
+        val competitorPrice = 89
+        val competitorLivingArea = 55
+        val competitorNrInsured = 2
+
+        val dataCollectionSlot = slot<UUID>()
+        every {
+            lookupServiceClient.getMatchingCompetitorPrice(capture(dataCollectionSlot),
+                "SEK",
+                "houseContentInsurance")
+        } returns
+            ResponseEntity(CompetitorPricing(
+                Money.of(81, "SEK"),
+                Money.of(competitorPrice, "SEK"),
+                Money.of(0, "SEK"),
+                "H Street 14",
+                "12345",
+                competitorLivingArea,
+                competitorNrInsured),
+                HttpStatus.OK)
+
+        // Create a quote WITHOUT data collectionId, should not call lookupService and not forward any competitor price to PE
+
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 55,
+            householdSize = 3,
+            dataCollectionId = null)
+
+        assertThat(dataCollectionSlot.isCaptured).isFalse()
+        assertThat(priceRequestSlot.captured.competitorPrice).isNull()
+
+        // Create a quote with data collectionId, and matching zipcode/livingSpace
+        dataCollectionSlot.clear()
+        var dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 55,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(dataCollectionSlot.captured).isEqualTo(dataCollectionId)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.price.compareTo(competitorPrice.toBigDecimal())).isEqualTo(
+            0)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.numberInsured).isEqualTo(competitorNrInsured)
+
+        // Create a quote with data collectionId, and matching livingSpace but NOT zipcode
+        // Should call the lookupService, AND should forward the competitor price
+        dataCollectionSlot.clear()
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "54321",
+            livingSpace = 55,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(dataCollectionSlot.captured).isEqualTo(dataCollectionId)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.price.compareTo(competitorPrice.toBigDecimal())).isEqualTo(
+            0)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.numberInsured).isEqualTo(competitorNrInsured)
+
+        // Create a quote with data collectionId, and matching zipCode but NOT livingSpace
+        // Should call the lookupService, and should forward the competitor price
+        dataCollectionSlot.clear()
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 56,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(dataCollectionSlot.captured).isEqualTo(dataCollectionId)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.price.compareTo(competitorPrice.toBigDecimal())).isEqualTo(
+            0)
+        assertThat(priceRequestSlot.captured.competitorPrice!!.numberInsured).isEqualTo(competitorNrInsured)
+
+        // Create a quote with data collectionId, and NOT matching zipCode or livingSpace
+        // Should call the lookupService, and NOT forward the competitor price
+        dataCollectionSlot.clear()
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "H Street 14, th. 1111 Wherever",
+            zip = "11111",
+            livingSpace = 99,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(dataCollectionSlot.captured).isEqualTo(dataCollectionId)
+        assertThat(priceRequestSlot.captured.competitorPrice).isNull()
+
+        // When the lookupService call fails, due to 404, 500 or error returned, the flow
+        // should not break and no competitor price will be forwarded
+        every {
+            lookupServiceClient.getMatchingCompetitorPrice(any(), any(), any())
+        } returns
+            ResponseEntity(HttpStatus.NOT_FOUND)
+
+
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 56,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(priceRequestSlot.captured.competitorPrice).isNull()
+
+
+        every {
+            lookupServiceClient.getMatchingCompetitorPrice(any(), any(), any())
+        } returns
+            ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
+
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 56,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(priceRequestSlot.captured.competitorPrice).isNull()
+
+
+        every {
+            lookupServiceClient.getMatchingCompetitorPrice(any(), any(), any())
+        } throws Exception("LookupServive error")
+
+        dataCollectionId = UUID.randomUUID()
+        quoteClient.createSwedishApartmentQuote(
+            street = "Test Apa",
+            zip = "12345",
+            livingSpace = 56,
+            dataCollectionId = dataCollectionId)
+
+        assertThat(priceRequestSlot.captured.competitorPrice).isNull()
+    }
+}


### PR DESCRIPTION
# Jira Issue: [IPC-65] 

## What?
- When dataCollectionId is present, call the lookupService for getting any matching competitor price and forward to price-engine.

## Why?
- To be able to match competitors price, we need to forward that information, when available, to price-engine

## Optional checklist
- [ ] Codescouted
- [x] Unit tests written
- [x] Tested locally



[IPC-65]: https://hedvig.atlassian.net/browse/IPC-65