### PR TITLE
MX-181: enable signing quotes with memberId injected, making underwriter not create a new member

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
@@ -222,7 +222,8 @@ class SignServiceImpl(
                     insuranceCompany = request.insuranceCompany,
                     email = request.email,
                     price = null,
-                    currency = null
+                    currency = null,
+                    memberId = request.memberId
                 )
             )
 
@@ -254,7 +255,7 @@ class SignServiceImpl(
         validateQuotesToSignFromRapio(quotes)
         validateBundlePrice(quotes, request.price, request.currency)
 
-        val memberId = getCreateMember(quotes)
+        val memberId = request.memberId ?: getCreateMember(quotes)
 
         quotes = quotes
             .map { it.copy(memberId = memberId) }

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/PriceQueryRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/PriceQueryRequest.kt
@@ -53,8 +53,12 @@ sealed class PriceQueryRequest {
     ) : PriceQueryRequest() {
         companion object {
             fun from(
-                quoteId: UUID, memberId: String?, partner: Partner, data: NorwegianHomeContentsData,
-                competitorPricing: CompetitorPricing?) =
+                quoteId: UUID,
+                memberId: String?,
+                partner: Partner,
+                data: NorwegianHomeContentsData,
+                competitorPricing: CompetitorPricing?
+            ) =
                 NorwegianHomeContent(
                     holderMemberId = memberId,
                     quoteId = quoteId,
@@ -80,8 +84,12 @@ sealed class PriceQueryRequest {
     ) : PriceQueryRequest() {
         companion object {
             fun from(
-                quoteId: UUID, memberId: String?, partner: Partner, data: NorwegianTravelData,
-                competitorPricing: CompetitorPricing?) = NorwegianTravel(
+                quoteId: UUID,
+                memberId: String?,
+                partner: Partner,
+                data: NorwegianTravelData,
+                competitorPricing: CompetitorPricing?
+            ) = NorwegianTravel(
                 holderMemberId = memberId,
                 quoteId = quoteId,
                 holderBirthDate = data.birthDate,
@@ -110,7 +118,8 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 data: SwedishApartmentData,
                 partner: Partner,
-                competitorPricing: CompetitorPricing?) = SwedishApartment(
+                competitorPricing: CompetitorPricing?
+            ) = SwedishApartment(
                 holderMemberId = memberId,
                 quoteId = quoteId,
                 holderBirthDate = data.birthDate ?: data.ssn!!.birthDateFromSwedishSsn(),
@@ -190,8 +199,12 @@ sealed class PriceQueryRequest {
     ) : PriceQueryRequest() {
         companion object {
             fun from(
-                quoteId: UUID, memberId: String?, partner: Partner, data: DanishHomeContentsData,
-                competitorPricing: CompetitorPricing?) =
+                quoteId: UUID,
+                memberId: String?,
+                partner: Partner,
+                data: DanishHomeContentsData,
+                competitorPricing: CompetitorPricing?
+            ) =
                 DanishHomeContent(
                     holderMemberId = memberId,
                     quoteId = quoteId,
@@ -229,8 +242,12 @@ sealed class PriceQueryRequest {
     ) : PriceQueryRequest() {
         companion object {
             fun from(
-                quoteId: UUID, memberId: String?, partner: Partner, data: DanishAccidentData,
-                competitorPricing: CompetitorPricing?) = DanishAccident(
+                quoteId: UUID,
+                memberId: String?,
+                partner: Partner,
+                data: DanishAccidentData,
+                competitorPricing: CompetitorPricing?
+            ) = DanishAccident(
                 holderMemberId = memberId,
                 quoteId = quoteId,
                 holderBirthDate = data.birthDate,
@@ -265,8 +282,12 @@ sealed class PriceQueryRequest {
     ) : PriceQueryRequest() {
         companion object {
             fun from(
-                quoteId: UUID, memberId: String?, partner: Partner, data: DanishTravelData,
-                competitorPricing: CompetitorPricing?) = DanishTravel(
+                quoteId: UUID,
+                memberId: String?,
+                partner: Partner,
+                data: DanishTravelData,
+                competitorPricing: CompetitorPricing?
+            ) = DanishTravel(
                 holderMemberId = memberId,
                 quoteId = quoteId,
                 holderBirthDate = data.birthDate,

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuoteRequestDto.kt
@@ -8,6 +8,7 @@ data class SignQuoteRequestDto(
     @Masked val name: Name?,
     @Masked val ssn: String?,
     val startDate: LocalDate?,
-    val insuranceCompany: String? = null,
-    @Masked val email: String
+    val insuranceCompany: String?,
+    @Masked val email: String,
+    val memberId: String?
 )

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/SignQuotesRequestDto.kt
@@ -13,17 +13,10 @@ data class SignQuotesRequestDto(
     val startDate: LocalDate?,
     val insuranceCompany: String?,
     @Masked val email: String,
-    val price: BigDecimal? = null, // Used for bundle verification
-    val currency: String? = null
-) {
-    companion object {
-        fun from(quoteId: UUID, request: SignQuoteRequestDto): SignQuotesRequestDto = SignQuotesRequestDto(
-            listOf(quoteId),
-            name = request.name,
-            ssn = request.ssn,
-            startDate = request.startDate,
-            insuranceCompany = request.insuranceCompany,
-            email = request.email
-        )
-    }
-}
+    val price: BigDecimal?, // Used for bundle verification
+    val currency: String?,
+    /**
+     * If set, Underwriter will use this member when signing a quote rather than creating a new one.
+     */
+    val memberId: String?
+)

--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
@@ -115,7 +115,7 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
         signServiceImpl.signQuoteFromRapio(
             quoteId,
             SignQuoteRequestDto(
-                Name("Mr Test", "Tester"), null, LocalDate.of(2020, 1, 1), null, "a@email.com"
+                Name("Mr Test", "Tester"), null, LocalDate.of(2020, 1, 1), null, "a@email.com", null
             )
         )
 

--- a/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/SignServiceImplTest.kt
@@ -142,7 +142,7 @@ class SignServiceImplTest {
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
 
-        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), null, "null"))
+        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), null, "null", null))
         verify { notificationService.postSignUpdate(ofType(Quote::class)) }
     }
 
@@ -171,7 +171,7 @@ class SignServiceImplTest {
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1234, true))
         every { memberService.isSsnAlreadySignedMemberEntity(any()) } returns IsSsnAlreadySignedMemberResponse(false)
 
-        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), "if", "null"))
+        cut.signQuoteFromRapio(quoteId, SignQuoteRequestDto(Name("", ""), null, LocalDate.now(), "if", "null", null))
         verify { notificationService.postSignUpdate(any()) }
     }
 
@@ -966,7 +966,8 @@ class SignServiceImplTest {
                 ssn = "191212121212",
                 startDate = null,
                 insuranceCompany = null,
-                email = "tolvan@tolvannsson.com"
+                email = "tolvan@tolvannsson.com",
+                memberId = null
             )
         )
         assertThat(result.isLeft()).isTrue()

--- a/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/UnderwriterImplTest.kt
@@ -77,7 +77,7 @@ class UnderwriterImplTest {
     @Test
     fun successfullyCreatesSwedishApartmentQuote() {
 
-        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics,  mockk())
+        val cut = UnderwriterImpl(priceEngineService, QuoteStrategyService(debtChecker, mockk()), requotingService, mockk(), metrics, mockk())
         val quoteRequest = SwedishApartmentQuoteRequestBuilder().build()
 
         every { debtChecker.passesDebtCheck(any()) } returns listOf()

--- a/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
@@ -361,10 +361,10 @@ class QuoteClient {
         lastName: String = "Apansson",
         email: String = "apan@apansson.se",
         ssn: String? = null,
-        startDate: String? = null
+        startDate: String? = null,
+        memberId: String? = null
     ): SignedQuoteResponseDto {
-
-        return signQuote<SignedQuoteResponseDto>(quoteId, firstName, lastName, email, ssn, startDate).body!!
+        return signQuote<SignedQuoteResponseDto>(quoteId, firstName, lastName, email, ssn, startDate, memberId).body!!
     }
 
     fun signQuoteRaw(
@@ -708,7 +708,8 @@ class QuoteClient {
         lastName: String,
         email: String,
         ssn: String? = null,
-        startDate: String? = null
+        startDate: String? = null,
+        memberId: String? = null
     ): ResponseEntity<T> {
 
         val ssnString = if (ssn != null) "\"$ssn\"" else "null"
@@ -721,7 +722,8 @@ class QuoteClient {
                 },
                 "ssn": $ssnString,
                 "startDate": "${startDate ?: LocalDate.now()}",
-                "email": "$email"
+                "email": "$email",
+                "memberId": ${memberId?.let { "\"$it\"" }}
             }
         """.trimIndent()
 

--- a/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
@@ -201,7 +201,6 @@ class CompetitorPriceIntegrationTest {
         } returns
             ResponseEntity(HttpStatus.NOT_FOUND)
 
-
         dataCollectionId = UUID.randomUUID()
         quoteClient.createSwedishApartmentQuote(
             street = "Test Apa",
@@ -210,7 +209,6 @@ class CompetitorPriceIntegrationTest {
             dataCollectionId = dataCollectionId)
 
         assertThat(priceRequestSlot.captured.competitorPrice).isNull()
-
 
         every {
             lookupServiceClient.getMatchingCompetitorPrice(any(), any(), any())
@@ -225,7 +223,6 @@ class CompetitorPriceIntegrationTest {
             dataCollectionId = dataCollectionId)
 
         assertThat(priceRequestSlot.captured.competitorPrice).isNull()
-
 
         every {
             lookupServiceClient.getMatchingCompetitorPrice(any(), any(), any())


### PR DESCRIPTION
# Jira Issue: [MX-181] 

## What?
- Enable injecting memberId when signing from Rapio, making it sign with that member rather than creating a new one

## Why?
- Members will be created before signing in the new AVY partnership use case.

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally



[MX-181]: https://hedvig.atlassian.net/browse/MX-181