### PR TITLE
MX-181: validate that injected members when signing from rapio don't already have a contract

### DIFF
--- a/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/service/CreateContractsFromQuotesSavesContractIdAndContractIdTest.kt
@@ -110,6 +110,7 @@ class CreateContractsFromQuotesSavesContractIdAndContractIdTest {
         every { productPricingService.createContractsFromQuotes(any(), any(), any()) } returns listOf(
             CreateContractResponse(quoteId, agreementId, contractId)
         )
+        every { productPricingService.hasContract(any()) } returns false
         every { memberService.signQuote(any(), any()) } returns Right(UnderwriterQuoteSignResponse(1L, true))
 
         signServiceImpl.signQuoteFromRapio(

--- a/src/test/kotlin/com/hedvig/underwriter/web/RapioIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/RapioIntegrationTest.kt
@@ -1622,6 +1622,9 @@ class RapioIntegrationTest : IntegrationTest() {
         every { productPricingClient.createContract(any(), any()) } returns listOf(
             CreateContractResponse(UUID.randomUUID(), agreementId, contractId)
         )
+        every {
+            productPricingClient.hasContract(any(), null).body
+        } returns false
         every { priceEngineClient.queryPrice(any()) } returns PriceQueryResponse(
             UUID.randomUUID(),
             Money.of(12, "SEK")


### PR DESCRIPTION
# Jira Issue: [MX-181] 

## What?
- When a "sign quotes from rapio" request comes in with an explicitly injected member ID, verify that said member don't already have a contract.

## Why?
- We want to enable signing of inejcted member IDs in the following cases:
  - the member only has a trial right now
  - the member does not have a trial, not a contract - i.e. it is "free"

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [ ] Tested locally



[MX-181]: https://hedvig.atlassian.net/browse/MX-181