### PR TITLE
Use Insurely net price

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/CompetitorPrice.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/CompetitorPrice.kt
@@ -10,7 +10,7 @@ data class CompetitorPrice(val price: BigDecimal, val numberInsured: Int?) {
         fun from(competitorPricing: CompetitorPricing?): CompetitorPrice? {
             return if (competitorPricing != null)
                 CompetitorPrice(
-                    competitorPricing.monthlyGrossPremium.number.numberValueExact(BigDecimal::class.java),
+                    competitorPricing.monthlyNetPremium.number.numberValueExact(BigDecimal::class.java),
                     competitorPricing.numberInsured)
             else null
         }


### PR DESCRIPTION
# Jira Issue: [IPC-170] 

## What?
- Use the net competitor price from Insurely instead of gross, when matching prices.

## Why?
- To offer more competetive prices 
- And cause the pricing guys says so :-) 

## Optional checklist
- [ ] Codescouted
- [x] Unit tests written
- [ ] Tested locally



[IPC-170]: https://hedvig.atlassian.net/browse/IPC-170