### PR TITLE
Feat/override quote price

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -265,7 +265,11 @@ data class Quote(
     val contractId: UUID? = null,
     val lineItems: List<LineItem> = emptyList(),
     @JsonIgnore
-    val competitorPricing: CompetitorPricing? = null // This field is not persisted
+    val competitorPricing: CompetitorPricing? = null,  // This field is not persisted
+    @JsonIgnore
+    val overriddenPrice: BigDecimal? = null,  // This field is not persisted
+    @JsonIgnore
+    val priceOverriddenBy: String? = null  // This field is not persisted
 ) {
     val isComplete: Boolean
         get() = when {

--- a/src/main/kotlin/com/hedvig/underwriter/service/QuoteService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/QuoteService.kt
@@ -10,6 +10,7 @@ import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.QuoteDto
 import com.hedvig.underwriter.web.dtos.AddAgreementFromQuoteRequest
 import com.hedvig.underwriter.web.dtos.CompleteQuoteResponseDto
 import com.hedvig.underwriter.web.dtos.ErrorResponseDto
+import java.math.BigDecimal
 import java.util.UUID
 
 interface QuoteService {
@@ -37,6 +38,8 @@ interface QuoteService {
         id: UUID,
         underwritingGuidelinesBypassedBy: String? = null
     ): Either<ErrorResponseDto, Quote>
+
+    fun overrideQuotePrice(quoteId: UUID, price: BigDecimal, overriddenBy: String): Either<ErrorResponseDto, Quote>
 
     fun removeCurrentInsurerFromQuote(
         id: UUID

--- a/src/main/kotlin/com/hedvig/underwriter/service/QuoteServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/QuoteServiceImpl.kt
@@ -37,7 +37,7 @@ import com.hedvig.underwriter.web.dtos.ErrorCodes
 import com.hedvig.underwriter.web.dtos.ErrorResponseDto
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import java.lang.IllegalStateException
+import java.math.BigDecimal
 import java.security.MessageDigest
 import java.time.Instant
 import java.util.UUID
@@ -76,6 +76,36 @@ class QuoteServiceImpl(
             .flatMap { updatedQuote ->
                 underwriter
                     .validateAndCompleteQuote(updatedQuote, underwritingGuidelinesBypassedBy)
+                    .mapLeft { e ->
+                        ErrorResponseDto(
+                            ErrorCodes.MEMBER_BREACHES_UW_GUIDELINES,
+                            "quote [Id: ${updatedQuote.id}] cannot be calculated, underwriting guidelines are breached [Quote: $updatedQuote]",
+                            e.second.map { BreachedGuideline("Deprecated", it) }
+                        )
+                    }
+            }.map { quoteRepository.update(it) }
+    }
+
+    override fun overrideQuotePrice(
+        quoteId: UUID,
+        price: BigDecimal,
+        overriddenBy: String
+    ): Either<ErrorResponseDto, Quote> {
+
+        return findQuoteOrError(quoteId)
+            .filterOrOther(
+                { it.state == QuoteState.QUOTED || it.state == QuoteState.INCOMPLETE },
+                {
+                    ErrorResponseDto(
+                        ErrorCodes.INVALID_STATE,
+                        "quote [Id: ${it.id}] must be quoted to override price but was really ${it.state} [Quote: $it]"
+                    )
+                }
+            )
+            .map { it.copy(overriddenPrice = price, priceOverriddenBy = overriddenBy) }
+            .flatMap { updatedQuote ->
+                underwriter
+                    .validateAndCompleteQuote(updatedQuote, null)
                     .mapLeft { e ->
                         ErrorResponseDto(
                             ErrorCodes.MEMBER_BREACHES_UW_GUIDELINES,

--- a/src/main/kotlin/com/hedvig/underwriter/service/RequotingServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/RequotingServiceImpl.kt
@@ -76,9 +76,15 @@ class RequotingServiceImpl(
             return newPrice
         }
 
+        // For overridden prices, we don't reuse old quotes
+        if (isOverriddenPrice(quote)) {
+            logger.info("Skip to reuse old price, since price is overridden: ${quote.id}")
+            return newPrice
+        }
+
         // Do not process certain "expensive" quotes
         if (isTooExpensive(quote)) {
-            logger.info("Skip if to reuse old price, too expensive check: ${quote.id}")
+            logger.info("Skip to reuse old price, too expensive check: ${quote.id}")
             return newPrice
         }
 
@@ -129,6 +135,10 @@ class RequotingServiceImpl(
 
         // If user has older quotes than 30 days and no changes since then it is time to change price
         return newPrice
+    }
+
+    private fun isOverriddenPrice(quote: Quote): Boolean {
+        return quote.overriddenPrice != null
     }
 
     private fun hasExistingAgreement(quote: Quote): Boolean {

--- a/src/main/kotlin/com/hedvig/underwriter/service/UnderwriterImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/UnderwriterImpl.kt
@@ -159,7 +159,9 @@ class UnderwriterImpl(
                     memberId = quote.memberId,
                     data = quote.data,
                     partner = quote.attributedTo,
-                    competitorPricing = quote.competitorPricing
+                    competitorPricing = quote.competitorPricing,
+                    overriddenPrice = quote.overriddenPrice,
+                    priceOverriddenBy = quote.priceOverriddenBy
                 )
             )
             is SwedishHouseData -> priceEngineService.querySwedishHousePrice(
@@ -168,7 +170,9 @@ class UnderwriterImpl(
                     quote.memberId,
                     quote.attributedTo,
                     quote.data,
-                    quote.competitorPricing
+                    quote.competitorPricing,
+                    quote.overriddenPrice,
+                    quote.priceOverriddenBy
                 )
             )
             is NorwegianHomeContentsData -> priceEngineService.queryNorwegianHomeContentPrice(
@@ -177,7 +181,9 @@ class UnderwriterImpl(
                     quote.memberId,
                     quote.attributedTo,
                     quote.data,
-                    quote.competitorPricing
+                    quote.competitorPricing,
+                    quote.overriddenPrice,
+                    quote.priceOverriddenBy
                 )
             )
             is NorwegianTravelData -> priceEngineService.queryNorwegianTravelPrice(
@@ -186,7 +192,9 @@ class UnderwriterImpl(
                     quote.memberId,
                     quote.attributedTo,
                     quote.data,
-                    quote.competitorPricing
+                    quote.competitorPricing,
+                    quote.overriddenPrice,
+                    quote.priceOverriddenBy
                 )
             )
             is DanishHomeContentsData -> {
@@ -196,7 +204,9 @@ class UnderwriterImpl(
                         quote.memberId,
                         quote.attributedTo,
                         quote.data,
-                        quote.competitorPricing
+                        quote.competitorPricing,
+                        quote.overriddenPrice,
+                        quote.priceOverriddenBy
                     )
                 )
             }
@@ -207,7 +217,9 @@ class UnderwriterImpl(
                         quote.memberId,
                         quote.attributedTo,
                         quote.data,
-                        quote.competitorPricing
+                        quote.competitorPricing,
+                        quote.overriddenPrice,
+                        quote.priceOverriddenBy
                     )
                 )
             }
@@ -218,7 +230,9 @@ class UnderwriterImpl(
                         quote.memberId,
                         quote.attributedTo,
                         quote.data,
-                        quote.competitorPricing
+                        quote.competitorPricing,
+                        quote.overriddenPrice,
+                        quote.priceOverriddenBy
                     )
                 )
             }

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/OverriddenPrice.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/OverriddenPrice.kt
@@ -1,0 +1,18 @@
+package com.hedvig.underwriter.serviceIntegration.priceEngine.dtos
+
+import java.math.BigDecimal
+
+data class OverriddenPrice(val price: BigDecimal, val overriddenBy: String) {
+
+    companion object {
+
+        fun from(price: BigDecimal?, overriddenBy: String?): OverriddenPrice? {
+            return if (price != null)
+                OverriddenPrice(
+                    price,
+                    overriddenBy!!
+                )
+            else null
+        }
+    }
+}

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/PriceQueryRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/priceEngine/dtos/PriceQueryRequest.kt
@@ -17,6 +17,7 @@ import com.hedvig.underwriter.model.SwedishHouseData
 import com.hedvig.underwriter.model.birthDateFromSwedishSsn
 import com.hedvig.underwriter.serviceIntegration.lookupService.dtos.CompetitorPricing
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.mappers.OutgoingMapper
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
@@ -39,6 +40,7 @@ sealed class PriceQueryRequest {
     abstract val numberCoInsured: Int
     abstract val partner: Partner
     abstract val competitorPrice: CompetitorPrice?
+    abstract val overriddenPrice: OverriddenPrice?
 
     data class NorwegianHomeContent(
         override val holderMemberId: String?,
@@ -47,6 +49,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val lineOfBusiness: NorwegianHomeContentLineOfBusiness,
         val postalCode: String,
         val squareMeters: Int
@@ -57,7 +60,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: NorwegianHomeContentsData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) =
                 NorwegianHomeContent(
                     holderMemberId = memberId,
@@ -68,7 +73,8 @@ sealed class PriceQueryRequest {
                     lineOfBusiness = OutgoingMapper.toLineOfBusiness(data.type, data.isYouth),
                     postalCode = data.zipCode,
                     squareMeters = data.livingSpace,
-                    competitorPrice = CompetitorPrice.from(competitorPricing)
+                    competitorPrice = CompetitorPrice.from(competitorPricing),
+                    overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
                 )
         }
     }
@@ -80,6 +86,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val lineOfBusiness: NorwegianTravelLineOfBusiness
     ) : PriceQueryRequest() {
         companion object {
@@ -88,7 +95,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: NorwegianTravelData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) = NorwegianTravel(
                 holderMemberId = memberId,
                 quoteId = quoteId,
@@ -96,7 +105,8 @@ sealed class PriceQueryRequest {
                 numberCoInsured = data.coInsured,
                 partner = partner,
                 lineOfBusiness = OutgoingMapper.toLineOfBusiness(data.isYouth),
-                competitorPrice = CompetitorPrice.from(competitorPricing)
+                competitorPrice = CompetitorPrice.from(competitorPricing),
+                overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
             )
         }
     }
@@ -108,6 +118,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val lineOfBusiness: SwedishApartmentLineOfBusiness,
         val squareMeters: Int,
         val postalCode: String
@@ -118,7 +129,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 data: SwedishApartmentData,
                 partner: Partner,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) = SwedishApartment(
                 holderMemberId = memberId,
                 quoteId = quoteId,
@@ -128,7 +141,8 @@ sealed class PriceQueryRequest {
                 lineOfBusiness = OutgoingMapper.toLineOfBusiness(data.subType!!),
                 squareMeters = data.livingSpace!!,
                 postalCode = data.zipCode!!,
-                competitorPrice = CompetitorPrice.from(competitorPricing)
+                competitorPrice = CompetitorPrice.from(competitorPricing),
+                overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
             )
         }
     }
@@ -140,6 +154,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val squareMeters: Int,
         val postalCode: String,
         val ancillaryArea: Int,
@@ -154,7 +169,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: SwedishHouseData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) = SwedishHouse(
                 holderMemberId = memberId,
                 quoteId = quoteId,
@@ -175,7 +192,8 @@ sealed class PriceQueryRequest {
                     )
                 },
                 isSubleted = data.isSubleted!!,
-                competitorPrice = CompetitorPrice.from(competitorPricing)
+                competitorPrice = CompetitorPrice.from(competitorPricing),
+                overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
             )
         }
     }
@@ -187,6 +205,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val squareMeters: Int,
         val bbrId: String?,
         val postalCode: String,
@@ -203,7 +222,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: DanishHomeContentsData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) =
                 DanishHomeContent(
                     holderMemberId = memberId,
@@ -220,7 +241,8 @@ sealed class PriceQueryRequest {
                     student = data.isStudent,
                     housingType = data.type,
                     squareMeters = data.livingSpace,
-                    competitorPrice = CompetitorPrice.from(competitorPricing)
+                    competitorPrice = CompetitorPrice.from(competitorPricing),
+                    overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
                 )
         }
     }
@@ -232,6 +254,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val bbrId: String?,
         val postalCode: String,
         val street: String,
@@ -246,7 +269,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: DanishAccidentData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) = DanishAccident(
                 holderMemberId = memberId,
                 quoteId = quoteId,
@@ -260,7 +285,8 @@ sealed class PriceQueryRequest {
                 floor = data.floor,
                 city = data.city,
                 student = data.isStudent,
-                competitorPrice = CompetitorPrice.from(competitorPricing)
+                competitorPrice = CompetitorPrice.from(competitorPricing),
+                overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
             )
         }
     }
@@ -272,6 +298,7 @@ sealed class PriceQueryRequest {
         override val numberCoInsured: Int,
         override val partner: Partner,
         override val competitorPrice: CompetitorPrice? = null,
+        override val overriddenPrice: OverriddenPrice? = null,
         val bbrId: String?,
         val postalCode: String,
         val street: String,
@@ -286,7 +313,9 @@ sealed class PriceQueryRequest {
                 memberId: String?,
                 partner: Partner,
                 data: DanishTravelData,
-                competitorPricing: CompetitorPricing?
+                competitorPricing: CompetitorPricing?,
+                overriddenPrice: BigDecimal?,
+                priceOverriddenBy: String?
             ) = DanishTravel(
                 holderMemberId = memberId,
                 quoteId = quoteId,
@@ -300,7 +329,8 @@ sealed class PriceQueryRequest {
                 floor = data.floor,
                 city = data.city,
                 student = data.isStudent,
-                competitorPrice = CompetitorPrice.from(competitorPricing)
+                competitorPrice = CompetitorPrice.from(competitorPricing),
+                overriddenPrice = OverriddenPrice.from(overriddenPrice, priceOverriddenBy)
             )
         }
     }

--- a/src/main/kotlin/com/hedvig/underwriter/web/dtos/OverridePriceRequestDto.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/web/dtos/OverridePriceRequestDto.kt
@@ -1,0 +1,9 @@
+package com.hedvig.underwriter.web.dtos
+
+import com.hedvig.libs.logging.masking.Masked
+import java.math.BigDecimal
+
+data class OverridePriceRequestDto(
+    val price: BigDecimal,
+    @Masked val overriddenBy: String
+)

--- a/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/testhelp/QuoteClient.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
@@ -792,6 +793,22 @@ class QuoteClient {
         """.trimIndent()
 
         return postJson("/_/v1/quotes/bundle/signFromRapio", request)
+    }
+
+    fun overrideQuotePrice(
+        quoteId: UUID,
+        price: BigDecimal?,
+        overriddenBy: String
+    ): ResponseEntity<Quote> {
+
+        val request = """
+                {
+                    "price": $price,
+                    "overriddenBy": "$overriddenBy"
+                }
+            """.trimIndent()
+
+        return postJson("/_/v1/quotes/$quoteId/overridePrice", request)
     }
 
     private inline fun <reified T : Any> postJson(url: String, data: String): ResponseEntity<T> {

--- a/src/test/kotlin/com/hedvig/underwriter/web/QuoteControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/QuoteControllerIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.hedvig.underwriter.web
 
 import assertk.assertThat
+import assertk.assertions.isEqualByComparingTo
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
@@ -12,6 +13,7 @@ import com.hedvig.underwriter.serviceIntegration.memberService.dtos.HelloHedvigR
 import com.hedvig.underwriter.serviceIntegration.memberService.dtos.PersonStatusDto
 import com.hedvig.underwriter.serviceIntegration.memberService.dtos.UnderwriterQuoteSignResponse
 import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.LineItem
+import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryRequest
 import com.hedvig.underwriter.serviceIntegration.priceEngine.dtos.PriceQueryResponse
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.contract.CreateContractResponse
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.contract.CreateContractsRequest
@@ -20,6 +22,7 @@ import com.hedvig.underwriter.testhelp.QuoteClient
 import io.mockk.every
 import io.mockk.slot
 import org.javamoney.moneta.Money
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
@@ -29,6 +32,28 @@ class QuoteControllerIntegrationTest : IntegrationTest() {
 
     @Autowired
     lateinit var quoteClient: QuoteClient
+
+    @BeforeEach
+    fun init() {
+
+        every { memberServiceClient.createMember() } returns ResponseEntity.status(200)
+            .body(HelloHedvigResponseDto("12345"))
+        every { memberServiceClient.signQuote(any(), any()) } returns ResponseEntity.status(200)
+            .body(UnderwriterQuoteSignResponse(1L, true))
+        every {
+            memberServiceClient.finalizeOnBoarding(
+                any(),
+                any()
+            )
+        } returns ResponseEntity.status(200).body("")
+        every { memberServiceClient.personStatus(any()) } returns ResponseEntity.status(200)
+            .body(PersonStatusDto(Flag.GREEN))
+
+        every { productPricingClient.hasContract(any(), any()) } returns ResponseEntity.status(200).body(false)
+        every { productPricingClient.createContract(any(), any()) } returns listOf(
+            CreateContractResponse(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
+        )
+    }
 
     @Test
     fun completeQuote() {
@@ -44,13 +69,10 @@ class QuoteControllerIntegrationTest : IntegrationTest() {
         val msFinalizeOnboardingRequest = slot<FinalizeOnBoardingRequest>()
 
         every { priceEngineClient.queryPrice(any()) } returns PriceQueryResponse(UUID.randomUUID(), Money.of(12, "SEK"), priceEngineLineItems)
-        every { memberServiceClient.createMember() } returns ResponseEntity.status(200).body(HelloHedvigResponseDto("12345"))
         every { productPricingClient.createContract(capture(quoteSlot), any()) } returns listOf(
             CreateContractResponse(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
         )
-        every { memberServiceClient.signQuote(any(), any()) } returns ResponseEntity.status(200).body(UnderwriterQuoteSignResponse(1L, true))
         every { memberServiceClient.finalizeOnBoarding(any(), capture(msFinalizeOnboardingRequest)) } returns ResponseEntity.status(200).body("")
-        every { memberServiceClient.personStatus(any()) } returns ResponseEntity.status(200).body(PersonStatusDto(Flag.GREEN))
 
         // WHEN
         val quoteResponse = quoteClient.createSwedishApartmentQuote(
@@ -113,6 +135,56 @@ class QuoteControllerIntegrationTest : IntegrationTest() {
             assertThat(floor).isEqualTo("2")
             assertThat(bbrId).isEqualTo("12345")
         }
+    }
+
+    @Test
+    fun `Test overriding of quote price`() {
+
+        // GIVEN
+        val ssn = "199507282383"
+        val defaultPremiumPrice = 12.0.toBigDecimal()
+
+        val quoteSlot = slot<CreateContractsRequest>()
+
+        every { priceEngineClient.queryPrice(any()) } answers {
+            PriceQueryResponse(
+                UUID.randomUUID(),
+                Money.of(firstArg<PriceQueryRequest>().overriddenPrice?.price ?: defaultPremiumPrice, "SEK")
+            )
+        }
+
+        every { productPricingClient.createContract(capture(quoteSlot), any()) } returns listOf(
+            CreateContractResponse(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID())
+        )
+
+        // WHEN
+        val quoteResponse = quoteClient.createSwedishApartmentQuote(
+            birthdate = "1995-07-28",
+            ssn = ssn
+        )
+
+        // Override price and assert the reponse
+        val overridePrice = 88.8.toBigDecimal()
+        val overriddenPriceQuote =
+            quoteClient.overrideQuotePrice(quoteResponse.id, overridePrice, "someone@hedvig,com")
+
+        quoteClient.signQuote(
+            quoteId = quoteResponse.id,
+            firstName = "Mr",
+            lastName = "Overrider",
+            email = "s@hedvig.com"
+        )
+
+        // THEN
+
+        // Verify the overridden price, both the API responses, the one sent to P&P and the ones exposed in the quote API
+        assertThat(quoteResponse.price).isEqualByComparingTo(defaultPremiumPrice)
+
+        assertThat(overriddenPriceQuote.body!!.price!!).isEqualByComparingTo(overridePrice)
+        assertThat(quoteSlot.captured.quotes.first().premium).isEqualByComparingTo(overridePrice)
+
+        val quote = quoteClient.getQuote(quoteResponse.id)
+        assertThat(quote!!.price!!).isEqualByComparingTo(overridePrice)
     }
 
     private fun assertProductPricingLineItems(


### PR DESCRIPTION
# Jira Issue: [IPC-134] 

## What?
- Add overrideQuotePrice REST endpoint, which allows for overriding quote's price
- Input parameters: quoteId, price and overiddenBy - will be called by backoffice
- UW basically sets those params and performs a validateAndCompleteQuote
- The overridden price and overiddenBy are forwarded to price-engine, so it can use them to calculate the correct final price and line items (e.g. tax), and also audit-log the details
- We explicitly avoid reusing any old price for these requests

## Why?
- To allow Hope users to override a quote's price

## Optional checklist
- [ ] Codescouted
- [x] Unit tests written
- [x] Tested locally



[IPC-134]: https://hedvig.atlassian.net/browse/IPC-134