### PR TITLE
Fix embedded postgres on m1 macs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
             <version>1.0.1</version>
         </dependency>
         <dependency>
-           <groupId>com.hedvig.libs</groupId>
-           <artifactId>translations</artifactId>
-           <version>0.3.0</version>
-       </dependency>
+            <groupId>com.hedvig.libs</groupId>
+            <artifactId>translations</artifactId>
+            <version>0.3.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
@@ -154,9 +154,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
-            <version>0.13.1</version>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/kotlin/com/hedvig/underwriter/testhelp/EmbeddedPostgresSingleton.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/testhelp/EmbeddedPostgresSingleton.kt
@@ -1,6 +1,6 @@
 package com.hedvig.underwriter.testhelp
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.apache.commons.lang.SystemUtils
 
 object EmbeddedPostgresSingleton {


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- Swap out embedded postgres to this [fork](https://github.com/zonkyio/embedded-postgres), which supports m1 macs without any hassle

## Why?
- So that people with m1 macs can run tests that rely on embedded postgres

## Optional checklist
- [x] Codescouted
- [ ] Unit tests written
- [x] Tested locally

