### PR TITLE
dont set bbrId from hope

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/graphql/type/QuoteMapper.kt
@@ -194,7 +194,6 @@ class QuoteMapper(
         is DanishHomeContentsData -> QuoteSchema.DanishHomeContent(
             street = quote.data.street,
             zipCode = quote.data.zipCode,
-            bbrId = quote.data.bbrId,
             city = quote.data.city,
             livingSpace = quote.data.livingSpace,
             numberCoInsured = quote.data.coInsured,
@@ -206,7 +205,6 @@ class QuoteMapper(
         is DanishAccidentData -> QuoteSchema.DanishAccident(
             street = quote.data.street,
             zipCode = quote.data.zipCode,
-            bbrId = quote.data.bbrId,
             city = quote.data.city,
             apartment = quote.data.apartment,
             floor = quote.data.floor,
@@ -216,7 +214,6 @@ class QuoteMapper(
         is DanishTravelData -> QuoteSchema.DanishTravel(
             street = quote.data.street,
             zipCode = quote.data.zipCode,
-            bbrId = quote.data.bbrId,
             city = quote.data.city,
             apartment = quote.data.apartment,
             floor = quote.data.floor,

--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -491,7 +491,6 @@ data class Quote(
                     else -> throw IllegalTypeChangeOnQuote(newQuote.data, requestData)
                 }
 
-
                 newQuote.copy(
                     data = newQuoteData.copy(
                         street = requestData.street ?: newQuoteData.street,

--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -265,11 +265,11 @@ data class Quote(
     val contractId: UUID? = null,
     val lineItems: List<LineItem> = emptyList(),
     @JsonIgnore
-    val competitorPricing: CompetitorPricing? = null,  // This field is not persisted
+    val competitorPricing: CompetitorPricing? = null, // This field is not persisted
     @JsonIgnore
-    val overriddenPrice: BigDecimal? = null,  // This field is not persisted
+    val overriddenPrice: BigDecimal? = null, // This field is not persisted
     @JsonIgnore
-    val priceOverriddenBy: String? = null  // This field is not persisted
+    val priceOverriddenBy: String? = null // This field is not persisted
 ) {
     val isComplete: Boolean
         get() = when {

--- a/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/model/Quote.kt
@@ -468,14 +468,6 @@ data class Quote(
                     else -> throw IllegalTypeChangeOnQuote(newQuote.data, requestData)
                 }
 
-                val addressInfoHasNotChanged = addressInfoHasNotChanged(
-                    street = requestData.street,
-                    floor = requestData.floor,
-                    apartment = requestData.apartment,
-                    zipCode = requestData.zipCode,
-                    city = requestData.city
-                )
-
                 newQuote.copy(
                     data = newQuoteData.copy(
                         street = requestData.street ?: newQuoteData.street,
@@ -483,7 +475,7 @@ data class Quote(
                         apartment = requestData.apartment ?: newQuoteData.apartment,
                         floor = requestData.floor ?: newQuoteData.floor,
                         city = requestData.city ?: newQuoteData.city,
-                        bbrId = requestData.bbrId ?: if (addressInfoHasNotChanged) newQuoteData.bbrId else null,
+                        bbrId = requestData.bbrId,
                         livingSpace = requestData.livingSpace ?: newQuoteData.livingSpace,
                         coInsured = requestData.coInsured ?: newQuoteData.coInsured,
                         isStudent = requestData.isStudent ?: newQuoteData.isStudent,
@@ -499,13 +491,6 @@ data class Quote(
                     else -> throw IllegalTypeChangeOnQuote(newQuote.data, requestData)
                 }
 
-                val addressInfoHasNotChanged = addressInfoHasNotChanged(
-                    street = requestData.street,
-                    floor = requestData.floor,
-                    apartment = requestData.apartment,
-                    zipCode = requestData.zipCode,
-                    city = requestData.city
-                )
 
                 newQuote.copy(
                     data = newQuoteData.copy(
@@ -514,7 +499,7 @@ data class Quote(
                         apartment = requestData.apartment ?: newQuoteData.apartment,
                         floor = requestData.floor ?: newQuoteData.floor,
                         city = requestData.city ?: newQuoteData.city,
-                        bbrId = requestData.bbrId ?: if (addressInfoHasNotChanged) newQuoteData.bbrId else null,
+                        bbrId = requestData.bbrId,
                         coInsured = requestData.coInsured ?: newQuoteData.coInsured,
                         isStudent = requestData.isStudent ?: newQuoteData.isStudent
                     )
@@ -528,14 +513,6 @@ data class Quote(
                     else -> throw IllegalTypeChangeOnQuote(newQuote.data, requestData)
                 }
 
-                val addressInfoHasNotChanged = addressInfoHasNotChanged(
-                    street = requestData.street,
-                    floor = requestData.floor,
-                    apartment = requestData.apartment,
-                    zipCode = requestData.zipCode,
-                    city = requestData.city
-                )
-
                 newQuote.copy(
                     data = newQuoteData.copy(
                         street = requestData.street ?: newQuoteData.street,
@@ -543,17 +520,13 @@ data class Quote(
                         apartment = requestData.apartment ?: newQuoteData.apartment,
                         floor = requestData.floor ?: newQuoteData.floor,
                         city = requestData.city ?: newQuoteData.city,
-                        bbrId = requestData.bbrId ?: if (addressInfoHasNotChanged) newQuoteData.bbrId else null,
+                        bbrId = requestData.bbrId,
                         coInsured = requestData.coInsured ?: newQuoteData.coInsured,
                         isStudent = requestData.isStudent ?: newQuoteData.isStudent
                     )
                 )
             }
         }
-    }
-
-    private fun addressInfoHasNotChanged(street: String?, zipCode: String?, apartment: String?, floor: String?, city: String?): Boolean {
-        return street == null && zipCode == null && apartment == null && floor == null && city == null
     }
 
     fun clearBreachedUnderwritingGuidelines(): Quote = this.copy(breachedUnderwritingGuidelines = listOf())

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequestData.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteRequestData.kt
@@ -272,7 +272,7 @@ sealed class QuoteRequestData {
                 city = quoteSchema.city,
                 apartment = quoteSchema.apartment,
                 floor = quoteSchema.floor,
-                bbrId = quoteSchema.bbrId,
+                bbrId = null,
                 livingSpace = quoteSchema.livingSpace,
                 coInsured = quoteSchema.numberCoInsured,
                 isStudent = quoteSchema.isStudent,
@@ -284,7 +284,7 @@ sealed class QuoteRequestData {
                 city = quoteSchema.city,
                 apartment = quoteSchema.apartment,
                 floor = quoteSchema.floor,
-                bbrId = quoteSchema.bbrId,
+                bbrId = null,
                 coInsured = quoteSchema.numberCoInsured,
                 isStudent = quoteSchema.isStudent
             )
@@ -294,7 +294,7 @@ sealed class QuoteRequestData {
                 city = quoteSchema.city,
                 apartment = quoteSchema.apartment,
                 floor = quoteSchema.floor,
-                bbrId = quoteSchema.bbrId,
+                bbrId = null,
                 coInsured = quoteSchema.numberCoInsured,
                 isStudent = quoteSchema.isStudent
             )

--- a/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteSchema.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/model/QuoteSchema.kt
@@ -113,8 +113,6 @@ sealed class QuoteSchema {
         val floor: String?,
         @JsonSchema(title = "City", required = false)
         val city: String?,
-        @JsonSchema(title = "BbrId", required = false)
-        @Masked val bbrId: String?,
         @JsonSchema(title = "Living Space", required = true, min = 0.0)
         val livingSpace: Int,
         @JsonSchema(title = "Number Co-Insured", required = true, min = 0.0)
@@ -136,8 +134,6 @@ sealed class QuoteSchema {
         val floor: String?,
         @JsonSchema(title = "City", required = false)
         val city: String?,
-        @JsonSchema(title = "BbrId", required = false)
-        @Masked val bbrId: String?,
         @JsonSchema(title = "Number Co-Insured", required = true, min = 0.0)
         val numberCoInsured: Int,
         @get:JsonProperty("isStudent")
@@ -157,8 +153,6 @@ sealed class QuoteSchema {
         val floor: String?,
         @JsonSchema(title = "City", required = false)
         val city: String?,
-        @JsonSchema(title = "BbrId", required = false)
-        @Masked val bbrId: String?,
         @JsonSchema(title = "Number Co-Insured", required = true, min = 0.0)
         val numberCoInsured: Int,
         @get:JsonProperty("isStudent")

--- a/src/test/kotlin/com/hedvig/underwriter/model/QuoteTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/model/QuoteTest.kt
@@ -164,7 +164,7 @@ class QuoteTest {
     }
 
     @Test
-    fun updatesQuoteButKeepsPreviousBbrIdIfHasNotChanged() {
+    fun `will update quote but keep previous bbrId if no changes to address have been made`() {
         val quote = Quote(
             id = UUID.randomUUID(),
             createdAt = Instant.now(),
@@ -178,38 +178,21 @@ class QuoteTest {
         )
 
         val danishHomeContentsQuoteData = DanishHomeContentsQuoteRequestDataBuilder().build()
+
+        val quoteDataThatDoesNotAmendAddress = danishHomeContentsQuoteData.copy(
+            street = null,
+            apartment = null,
+            floor = null,
+            zipCode = null,
+            city = null
+        )
+
         val updatedQuote = quote.update(
-            DanishHomeContentsQuoteRequestBuilder().build(danishHomeContentsQuoteData, "201212121212")
+            DanishHomeContentsQuoteRequestBuilder().build(quoteDataThatDoesNotAmendAddress, "201212121212")
         )
         assertThat(updatedQuote.id).isEqualTo(quote.id)
         assertThat((updatedQuote.data as DanishHomeContentsData).ssn).isEqualTo("201212121212")
         assertThat((updatedQuote.data as DanishHomeContentsData).bbrId).isEqualTo((quote.data as DanishHomeContentsData).bbrId)
-    }
-
-    @Test
-    fun updatesQuoteButKeepsPreviousBbrIdIfHasBeenUpdated() {
-        val quote = Quote(
-            id = UUID.randomUUID(),
-            createdAt = Instant.now(),
-            data = DanishHomeContentsDataBuilder().build(),
-            productType = ProductType.HOME_CONTENT,
-            initiatedFrom = QuoteInitiatedFrom.HOPE,
-            attributedTo = Partner.HEDVIG,
-            state = QuoteState.QUOTED,
-            breachedUnderwritingGuidelines = null,
-            price = BigDecimal.valueOf(100)
-        )
-
-        val danishHomeContentsQuoteData = DanishHomeContentsQuoteRequestDataBuilder().build(
-            newStreet = null,
-            newZipCode = null,
-            newBbrId = "5455"
-        )
-        val updatedQuote = quote.update(
-            DanishHomeContentsQuoteRequestBuilder().build(homeContentsData = danishHomeContentsQuoteData)
-        )
-        assertThat(updatedQuote.id).isEqualTo(quote.id)
-        assertThat((updatedQuote.data as DanishHomeContentsData).bbrId).isEqualTo("5455")
     }
 
     @Test
@@ -236,33 +219,5 @@ class QuoteTest {
         assertThat(updatedQuote.id).isEqualTo(quote.id)
         assertThat((updatedQuote.data as DanishHomeContentsData).zipCode).isEqualTo((quote.data as DanishHomeContentsData).zipCode)
         assertThat((updatedQuote.data as DanishHomeContentsData).bbrId).isNull()
-    }
-
-    @Test
-    fun `if city or street is changed when editing quote and brrId is updated (before we have autocomplete implemented) use updated bbrId`() {
-        val quote = Quote(
-            id = UUID.randomUUID(),
-            createdAt = Instant.now(),
-            data = DanishHomeContentsDataBuilder().build(),
-            productType = ProductType.HOME_CONTENT,
-            initiatedFrom = QuoteInitiatedFrom.HOPE,
-            attributedTo = Partner.HEDVIG,
-            state = QuoteState.QUOTED,
-            breachedUnderwritingGuidelines = null,
-            price = BigDecimal.valueOf(100)
-        )
-
-        val danishHomeContentsQuoteData = DanishHomeContentsQuoteRequestDataBuilder().build(
-            newStreet = "new street",
-            newZipCode = "newZip",
-            newBbrId = "6554"
-        )
-        val updatedQuote = quote.update(
-            DanishHomeContentsQuoteRequestBuilder().build(homeContentsData = danishHomeContentsQuoteData)
-        )
-        assertThat(updatedQuote.id).isEqualTo(quote.id)
-        assertThat((updatedQuote.data as DanishHomeContentsData).bbrId).isEqualTo("6554")
-        assertThat((updatedQuote.data as DanishHomeContentsData).street).isEqualTo("new street")
-        assertThat((updatedQuote.data as DanishHomeContentsData).zipCode).isEqualTo("newZip")
     }
 }

--- a/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/CompetitorPriceIntegrationTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualByComparingTo
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
-import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.hedvig.productPricingObjects.dtos.Agreement
 import com.hedvig.productPricingObjects.enums.AgreementStatus

--- a/src/test/kotlin/com/hedvig/underwriter/web/QuoteSchemaControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/QuoteSchemaControllerTest.kt
@@ -1,11 +1,8 @@
 package com.hedvig.underwriter.web
 
 import arrow.core.Either
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.imifou.jsonschema.module.addon.annotation.JsonSchema
-import com.hedvig.libs.logging.masking.Masked
 import com.hedvig.underwriter.model.ContractType
 import com.hedvig.underwriter.service.QuoteSchemaService
 import com.hedvig.underwriter.service.QuoteService
@@ -98,7 +95,6 @@ internal class QuoteSchemaControllerTest {
             "isYouth": ${SCHEMA_DATA.isYouth} 
         }
     """.trimIndent()
-
 
     private val SCHEMA_DATA_JSON_DENMARK_TRAVEL = """
         {

--- a/src/test/kotlin/com/hedvig/underwriter/web/QuoteSchemaControllerTest.kt
+++ b/src/test/kotlin/com/hedvig/underwriter/web/QuoteSchemaControllerTest.kt
@@ -105,8 +105,7 @@ internal class QuoteSchemaControllerTest {
             "floor": "${SCHEMA_DATA_DANISH_TRAVEL.floor}",
             "city": "${SCHEMA_DATA_DANISH_TRAVEL.city}",
             "numberCoInsured": ${SCHEMA_DATA_DANISH_TRAVEL.numberCoInsured},
-            "isStudent": ${SCHEMA_DATA_DANISH_TRAVEL.isStudent},
-            "bbrId": "6A3FDA02-4A21-49E4-8E10-F94F93AFDA4C"
+            "isStudent": ${SCHEMA_DATA_DANISH_TRAVEL.isStudent}
         }
     """.trimIndent()
 


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- from hope we always send in all quote data when updating a quote. This means that if a member has gone through the onboarding with autocomplete and then iex amend the address details the old brrId from the previous quote will get sent (unless iex delete the bbrId field).
- In underwriter, we expect that when we edit a quote we will only get data for fields that will be updated. It turns out that from hope and the web this is not the case (though this is the case for apps). We will need to align and fix this (but that will come in another pr).
- this removes bbrId from the quote schema as we are not using autocomplete in hope. This means the bbrId will be set to null in all cases.
- If a member has changed something (other than the address) on the quote, geomatic should still be able to find them based on the other address fields even though the brrId is null.

## Why?
- 

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally

