### PR TITLE
MX-205: forward initiated_from as sign source in the self-change codepath

### DIFF
--- a/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/service/SignServiceImpl.kt
@@ -430,6 +430,7 @@ class SignServiceImpl(
         }
         val result = productPricingService.selfChangeContracts(
             memberId = memberId,
+            initiatedFrom = quotes.first().initiatedFrom,
             quotes = quotes
         )
         val changes = result.createdContracts + result.updatedContracts

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/ProductPricingService.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/ProductPricingService.kt
@@ -3,6 +3,7 @@ package com.hedvig.underwriter.serviceIntegration.productPricing
 import com.hedvig.productPricingObjects.dtos.Agreement
 import com.hedvig.underwriter.graphql.type.InsuranceCost
 import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.CalculateBundleInsuranceCostRequest
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.RedeemCampaignDto
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.SelfChangeResult
@@ -42,5 +43,5 @@ interface ProductPricingService {
 
     fun getAgreement(agreementId: UUID): Agreement
 
-    fun selfChangeContracts(memberId: String, quotes: List<Quote>): SelfChangeResult
+    fun selfChangeContracts(memberId: String, initiatedFrom: QuoteInitiatedFrom, quotes: List<Quote>): SelfChangeResult
 }

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/ProductPricingServiceImpl.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/ProductPricingServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hedvig.underwriter.serviceIntegration.productPricing
 import com.hedvig.productPricingObjects.dtos.Agreement
 import com.hedvig.underwriter.graphql.type.InsuranceCost
 import com.hedvig.underwriter.model.Quote
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.AddAgreementRequest
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.CalculateBundleInsuranceCostRequest
 import com.hedvig.underwriter.serviceIntegration.productPricing.dtos.CalculateInsuranceCostRequest
@@ -79,10 +80,15 @@ class ProductPricingServiceImpl @Autowired constructor(
     override fun getAgreement(agreementId: UUID): Agreement =
         productPricingClient.getAgreement(agreementId).body!!
 
-    override fun selfChangeContracts(memberId: String, quotes: List<Quote>): SelfChangeResult =
+    override fun selfChangeContracts(
+        memberId: String,
+        initiatedFrom: QuoteInitiatedFrom,
+        quotes: List<Quote>
+    ): SelfChangeResult =
         productPricingClient.selfChangeContracts(
             SelfChangeRequest(
                 memberId = memberId,
+                signSource = initiatedFrom,
                 quotes = quotes.map { OutgoingMapper.toAgreementQuote(it) }
             )
         )

--- a/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/SelfChangeRequest.kt
+++ b/src/main/kotlin/com/hedvig/underwriter/serviceIntegration/productPricing/dtos/SelfChangeRequest.kt
@@ -1,8 +1,10 @@
 package com.hedvig.underwriter.serviceIntegration.productPricing.dtos
 
 import com.hedvig.productPricingObjects.dtos.AgreementQuote
+import com.hedvig.underwriter.model.QuoteInitiatedFrom
 
 class SelfChangeRequest(
     val memberId: String,
+    val signSource: QuoteInitiatedFrom,
     val quotes: List<AgreementQuote>
 )


### PR DESCRIPTION
# Jira Issue: [MX-205] 

## What?
- send signSource in self-change codepath

## Why?
- it's valuable information we didn't send before in these endpoints

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [ ] Tested locally



[MX-205]: https://hedvig.atlassian.net/browse/MX-205